### PR TITLE
[DAD-615] 편집하기로 삭제 후 다시 편집하기 열었을 때 내용 사라지는 오류 개선

### DIFF
--- a/src/components/molcules/ArticleScrapCard.tsx
+++ b/src/components/molcules/ArticleScrapCard.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { contentProps } from '../organisms/ScrapCard';
+import { contentProps } from '../../types/ContentType';
 import Memo from './Memo';
 import Chip from '../atoms/Chip';
 import Button from '../atoms/DefaultButton';

--- a/src/components/molcules/OtherScrapCard.tsx
+++ b/src/components/molcules/OtherScrapCard.tsx
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
 
-import { contentProps } from '../organisms/ScrapCard';
 import Memo from './Memo';
 import Button from '../atoms/DefaultButton';
 import MoreIcon from '../../assets/icons/MoreVerticalIcon.png';
 
 import theme from '../../assets/styles/theme';
+import { contentProps } from '../../types/ContentType';
 
 interface OtherScrapCardProps {
     content: contentProps['content'],

--- a/src/components/molcules/ProductScrapCard.tsx
+++ b/src/components/molcules/ProductScrapCard.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { contentProps } from '../organisms/ScrapCard';
+import { contentProps } from '../../types/ContentType';
 import Memo from './Memo';
 import Button from '../atoms/DefaultButton';
 import Chip from '../atoms/Chip';

--- a/src/components/molcules/VideoScrapCard.tsx
+++ b/src/components/molcules/VideoScrapCard.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { contentProps } from '../organisms/ScrapCard';
+import { contentProps } from '../../types/ContentType';
 import Memo from './Memo';
 import Button from '../atoms/DefaultButton';
 import Chip from '../atoms/Chip';

--- a/src/components/organisms/ExistListScrapContainer.tsx
+++ b/src/components/organisms/ExistListScrapContainer.tsx
@@ -1,15 +1,11 @@
 import styled from "styled-components"
 import { Masonry } from "@mui/lab"
-
-import OtherScrapCard from "../molcules/OtherScrapCard"
-import ProductScrapCard from "../molcules/ProductScrapCard"
-import VideoScrapCard from "../molcules/VideoScrapCard"
-import ArticleScrapCard from "../molcules/ArticleScrapCard"
-import { useEffect, useRef, useState } from "react"
+import { useState } from "react"
 import { CircularProgress } from "@mui/material"
+
+import ScrapCard from "./ScrapCard"
 import useInfiniteScroll from "../../hooks/useInfiniteScroll"
 import theme from "../../assets/styles/theme"
-import ScrapCard from "./ScrapCard"
 
 interface ExistListScrapContainerProps {
     contents: {

--- a/src/components/organisms/ExistOtherScrapContainer.tsx
+++ b/src/components/organisms/ExistOtherScrapContainer.tsx
@@ -3,7 +3,8 @@ import { useState } from "react";
 import { Masonry } from "@mui/lab"
 import { CircularProgress } from "@mui/material";
 
-import ScrapCard, { contentProps } from "./ScrapCard";
+import ScrapCard from "./ScrapCard";
+import { contentProps } from '../../types/ContentType';
 import useInfiniteScroll from "../../hooks/useInfiniteScroll";
 import theme from "../../assets/styles/theme";
 

--- a/src/components/organisms/ScrapCard.tsx
+++ b/src/components/organisms/ScrapCard.tsx
@@ -12,35 +12,7 @@ import ArticleScrapCard from '../molcules/ArticleScrapCard';
 import ErrorHandler from '../../utility/ErrorHandler';
 
 import theme from '../../assets/styles/theme';
-
-export interface contentProps {
-    content: {
-        pageUrl: string,
-        title?: string,
-        description?: string,
-        thumbnailUrl?: string,
-        scrapCreatedDate?: string,
-        scrapId: number,
-        memoList: {
-            memoId: number,
-            memoImageUrl?: string,
-            memoText?: string,
-        }[],
-        siteName?: string,
-        author?: string,
-        authorImageUrl?: string,
-        blogName?: string,
-        publishedDate?: string,
-        price?: string,
-        channelImageUrl?: string,
-        channelName?: string,
-        embedUrl?: string,
-        genre?: string,
-        playTime?: string,
-        watchedCnt?: string,
-        dtype: string,
-    }
-}
+import { contentProps } from '../../types/ContentType';
 
 function ScrapCard({ content }: contentProps) {
     const scrapCardMenu = [{

--- a/src/components/organisms/ScrapCard.tsx
+++ b/src/components/organisms/ScrapCard.tsx
@@ -21,11 +21,11 @@ export interface contentProps {
         thumbnailUrl?: string,
         scrapCreatedDate?: string,
         scrapId: number,
-        memoList: [{
+        memoList: {
             memoId: number,
             memoImageUrl?: string,
             memoText?: string,
-        }],
+        }[],
         siteName?: string,
         author?: string,
         authorImageUrl?: string,

--- a/src/components/organisms/ScrapEditModal.tsx
+++ b/src/components/organisms/ScrapEditModal.tsx
@@ -95,14 +95,14 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             showState: () => setBlogName(content.blogName),
             setState: setBlogName,
         },
-        // {
-        //     name: 'publishedDate',
-        //     label: '게시일',
-        //     isDeleteable: true,
-        //     state: publishedDate,
-        //     showState: () => setPublishedDate(content.publishedDate),
-        //     setState: setPublishedDate,
-        // },
+        {
+            name: 'publishedDate',
+            label: '게시일',
+            isDeleteable: true,
+            state: publishedDate,
+            showState: () => setPublishedDate(content.publishedDate),
+            setState: setPublishedDate,
+        },
         {
             name: 'price',
             label: '가격',
@@ -127,14 +127,14 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             showState: () => setPlayTime(content.playTime),
             setState: setPlayTime,
         },
-        // {
-        //     name: 'watchedCnt',
-        //     label: '조회수',
-        //     isDeleteable: true,
-        //     state: watchedCnt,
-        //     showState: () => setWatchedCnt(content.watchedCnt),
-        //     setState: setWatchedCnt,
-        // },
+        {
+            name: 'watchedCnt',
+            label: '조회수',
+            isDeleteable: true,
+            state: watchedCnt,
+            showState: () => setWatchedCnt(content.watchedCnt),
+            setState: setWatchedCnt,
+        },
     ];
 
     const emptyMemoText = '메모를 입력하세요';

--- a/src/components/organisms/ScrapEditModal.tsx
+++ b/src/components/organisms/ScrapEditModal.tsx
@@ -33,6 +33,14 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
         memoText?: string,
     }[] | undefined>(content.memoList);
 
+    const isNotNullOrUndefined = (state: any) => {
+        if (state === null || state === undefined) {
+            return false;
+        }
+
+        return true;
+    }
+
     const editalbeContent = {
         'title': {
             label: '제목',
@@ -41,6 +49,9 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             state: title,
             showState: () => { setTitle(content.title) },
             setState: setTitle,
+            setIsDeleted(value: boolean) {
+                editalbeContent.title.isDeleted = value;
+            }
         },
         'description': {
             label: '설명',
@@ -49,6 +60,9 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             state: description,
             showState: () => setDescription(content.description),
             setState: setDescription,
+            setIsDeleted(value: boolean) {
+                editalbeContent.description.isDeleted = value;
+            }
         },
         'siteName': {
             label: '사이트명',
@@ -57,6 +71,9 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             state: siteName,
             showState: () => setSiteName(content.siteName),
             setState: setSiteName,
+            setIsDeleted(value: boolean) {
+                editalbeContent.siteName.isDeleted = value;
+            }
         },
         'author': {
             label: '저자',
@@ -65,6 +82,9 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             state: author,
             showState: () => setAuthor(content.author),
             setState: setAuthor,
+            setIsDeleted(value: boolean) {
+                editalbeContent.author.isDeleted = value;
+            }
         },
         'blogName': {
             label: '블로그명',
@@ -73,6 +93,9 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             state: blogName,
             showState: () => setBlogName(content.blogName),
             setState: setBlogName,
+            setIsDeleted(value: boolean) {
+                editalbeContent.blogName.isDeleted = value;
+            }
         },
         'publishedDate': {
             label: '게시일',
@@ -81,6 +104,9 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             state: publishedDate,
             showState: () => setPublishedDate(content.publishedDate),
             setState: setPublishedDate,
+            setIsDeleted(value: boolean) {
+                editalbeContent.publishedDate.isDeleted = value;
+            }
         },
         'price': {
             label: '가격',
@@ -89,6 +115,9 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             state: price,
             showState: () => setPrice(content.price),
             setState: setPrice,
+            setIsDeleted(value: boolean) {
+                editalbeContent.price.isDeleted = value;
+            }
         },
         'channelName': {
             label: '채널명',
@@ -97,6 +126,9 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             state: channelName,
             showState: () => setChannelName(content.channelName),
             setState: setChannelName,
+            setIsDeleted(value: boolean) {
+                editalbeContent.channelName.isDeleted = value;
+            }
         },
         'playTime': {
             label: '영상 길이',
@@ -105,6 +137,9 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             state: playTime,
             showState: () => setPlayTime(content.playTime),
             setState: setPlayTime,
+            setIsDeleted(value: boolean) {
+                editalbeContent.playTime.isDeleted = value;
+            }
         },
         'watchedCnt': {
             label: '조회수',
@@ -113,6 +148,9 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             state: watchedCnt,
             showState: () => setWatchedCnt(content.watchedCnt),
             setState: setWatchedCnt,
+            setIsDeleted(value: boolean) {
+                editalbeContent.watchedCnt.isDeleted = value;
+            }
         },
     };
 
@@ -127,7 +165,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
 
         defaultContentMenu[content.dtype as keyof typeof defaultContentMenu].map((name) => {
             const element = editalbeContent[name as keyof typeof editalbeContent];
-            if (!element.state) {
+            if (!isNotNullOrUndefined(element.state)) {
                 element.isDeleted = true;
             }
         });
@@ -135,7 +173,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
 
     useEffect(() => {
         setToken(localStorage.getItem('token'));
-    }, []);
+    });
 
     initiateEditableContent();
 
@@ -184,12 +222,12 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
                 .catch(err => setError(err.message));
     }
 
+
     const contentRendering = () => {
         const renderingResult = [];
         for (const key in editalbeContent) {
             const element = editalbeContent[key as keyof typeof editalbeContent];
-            console.log('notDeleted', element.isDeleted);
-            (!element.isDeleted && element.state)
+            (!element.isDeleted && isNotNullOrUndefined(element.state))
                 && renderingResult.push(
                     <div>
                         {
@@ -211,14 +249,17 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
         const renderingResult = [];
         for (const key in editalbeContent) {
             const element = editalbeContent[key as keyof typeof editalbeContent];
-            console.log('deleted', element.isDeleted);
             element.isDeleted
                 && renderingResult.push(
                     <div>
                         {
                             <AddableElement
                                 elementTitle={element.label}
-                                onClick={() => element.isDeleted = false}
+                                key={element.label + content.scrapId}
+                                onClick={() => {
+                                    element.setState('');
+                                    element.setIsDeleted(false);
+                                }}
                             />
                         }
                     </div>

--- a/src/components/organisms/ScrapEditModal.tsx
+++ b/src/components/organisms/ScrapEditModal.tsx
@@ -33,9 +33,8 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
         memoText?: string,
     }[] | undefined>(content.memoList);
 
-    const editalbeContent = [
-        {
-            name: 'title',
+    const editalbeContent = {
+        'title': {
             label: '제목',
             isDeleteable: true,
             isDeleted: false,
@@ -43,8 +42,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             showState: () => { setTitle(content.title) },
             setState: setTitle,
         },
-        {
-            name: 'description',
+        'description': {
             label: '설명',
             isDeleteable: true,
             isDeleted: false,
@@ -52,8 +50,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             showState: () => setDescription(content.description),
             setState: setDescription,
         },
-        {
-            name: 'siteName',
+        'siteName': {
             label: '사이트명',
             isDeleteable: true,
             isDeleted: false,
@@ -61,8 +58,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             showState: () => setSiteName(content.siteName),
             setState: setSiteName,
         },
-        {
-            name: 'author',
+        'author': {
             label: '저자',
             isDeleteable: true,
             isDeleted: false,
@@ -70,8 +66,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             showState: () => setAuthor(content.author),
             setState: setAuthor,
         },
-        {
-            name: 'blogName',
+        'blogName': {
             label: '블로그명',
             isDeleteable: true,
             isDeleted: false,
@@ -79,8 +74,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             showState: () => setBlogName(content.blogName),
             setState: setBlogName,
         },
-        {
-            name: 'publishedDate',
+        'publishedDate': {
             label: '게시일',
             isDeleteable: true,
             isDeleted: false,
@@ -88,8 +82,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             showState: () => setPublishedDate(content.publishedDate),
             setState: setPublishedDate,
         },
-        {
-            name: 'price',
+        'price': {
             label: '가격',
             isDeleteable: true,
             isDeleted: false,
@@ -97,8 +90,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             showState: () => setPrice(content.price),
             setState: setPrice,
         },
-        {
-            name: 'channelName',
+        'channelName': {
             label: '채널명',
             isDeleteable: true,
             isDeleted: false,
@@ -106,8 +98,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             showState: () => setChannelName(content.channelName),
             setState: setChannelName,
         },
-        {
-            name: 'playTime',
+        'playTime': {
             label: '영상 길이',
             isDeleteable: true,
             isDeleted: false,
@@ -115,8 +106,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             showState: () => setPlayTime(content.playTime),
             setState: setPlayTime,
         },
-        {
-            name: 'watchedCnt',
+        'watchedCnt': {
             label: '조회수',
             isDeleteable: true,
             isDeleted: false,
@@ -124,9 +114,22 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             showState: () => setWatchedCnt(content.watchedCnt),
             setState: setWatchedCnt,
         },
-    ];
+    };
 
     const [token, setToken] = useState<string | null>(null);
+    function initiateEditableContent() {
+        const defaultContentMenu = {
+            other: ['title', 'description'],
+            article: ['title', 'description', 'siteName', 'author', 'blogName', 'publishedDate'],
+            product: ['title', 'description', 'siteName', 'price'],
+            video: ['title', 'description', 'siteName', 'channelName', 'playTime', 'watchedCnt', 'publishedDate'],
+        };
+
+        // defaultContentMenu[content.dtype as keyof typeof defaultContentMenu].map((name) => {
+        //     if (editalbeContent)
+        // })
+    }
+
     useEffect(() => {
         setToken(localStorage.getItem('token'));
 
@@ -142,12 +145,12 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
     };
 
     const editScrap = () => {
-        editalbeContent.map((item) => {
+        for (const key in editalbeContent) {
             content = {
                 ...content,
-                [item.name]: item.state,
+                [key]: editalbeContent[key as keyof typeof editalbeContent].state,
             }
-        });
+        }
 
         if (memos) {
             content = { ...content, memoList: memos }
@@ -177,6 +180,46 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
                 .catch(err => setError(err.message));
     }
 
+    const contentRendering = () => {
+        const renderingResult = [];
+        for (const key in editalbeContent) {
+            const element = editalbeContent[key as keyof typeof editalbeContent];
+            !element.isDeleted && renderingResult.push(
+                <div>
+                    {
+                        < TextArea
+                            labelText={element.label}
+                            defaultValue={content[key as keyof typeof content] as string}
+                            setState={element.setState}
+                            key={element.label + content.scrapId}
+                            isDeleteable={element.isDeleteable}
+                        />
+                    }
+                </div>);
+        }
+
+        return renderingResult;
+    }
+
+    const deletedContentRendering = () => {
+        const renderingResult = [];
+        for (const key in editalbeContent) {
+            const element = editalbeContent[key as keyof typeof editalbeContent];
+            element.isDeleted && renderingResult.push(
+                <div>
+                    {
+                        <AddableElement
+                            elementTitle={element.label}
+                            onClick={element.showState}
+                        />
+                    }
+                </div>
+            );
+        }
+
+        return renderingResult;
+    }
+
     return (
         <ModalWrapper>
             <ModalHeader>
@@ -186,24 +229,13 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
                 <IconContainer hideScrapEditModal={hideScrapEditModal} />
             </ModalHeader>
             <ContentWrapper>
-                {editalbeContent.map(element => {
-                    return (content[element.name as keyof typeof content] && element.state !== null) &&
-                        <TextArea
-                            labelText={element.label}
-                            defaultValue={content[element.name as keyof typeof content] as string}
-                            setState={element.setState}
-                            key={element.label + content.scrapId}
-                            isDeleteable={element.isDeleteable}
-                        />
-                })}
+                {contentRendering()}
                 {memos &&
                     <MemoTextArea memos={memos} setMemos={setMemos} />
                 }
                 <ContentAddSection>
                     <DefaultTypography>추가하기</DefaultTypography>
-                    {editalbeContent.map(element => {
-                        return (content[element.name as keyof typeof content] && element.state === null) && <AddableElement elementTitle={element.label} onClick={element.showState} />
-                    })}
+                    {deletedContentRendering()}
                     <AddableElement elementTitle={'메모'} onClick={() => createMemo()} />
                 </ContentAddSection>
             </ContentWrapper>

--- a/src/components/organisms/ScrapEditModal.tsx
+++ b/src/components/organisms/ScrapEditModal.tsx
@@ -149,11 +149,6 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             }
         });
 
-        // setMemos(memos?.filter(memo => memo.memoImageURL || (memo.memoText && memo.memoText.length > 0)));
-        // memos?.map(memo => {
-        //    console.log(memo.memoImageURL || (memo.memoText && memo.memoText.length > 0));
-        // })
-
         if (memos) {
             content = { ...content, memoList: memos }
         }

--- a/src/components/organisms/ScrapEditModal.tsx
+++ b/src/components/organisms/ScrapEditModal.tsx
@@ -97,17 +97,17 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
                 editalbeContent.blogName.isDeleted = value;
             }
         },
-        'publishedDate': {
-            label: '게시일',
-            isDeleteable: true,
-            isDeleted: false,
-            state: publishedDate,
-            showState: () => setPublishedDate(content.publishedDate),
-            setState: setPublishedDate,
-            setIsDeleted(value: boolean) {
-                editalbeContent.publishedDate.isDeleted = value;
-            }
-        },
+        // 'publishedDate': {
+        //     label: '게시일',
+        //     isDeleteable: false,
+        //     isDeleted: false,
+        //     state: publishedDate,
+        //     showState: () => setPublishedDate(content.publishedDate),
+        //     setState: setPublishedDate,
+        //     setIsDeleted(value: boolean) {
+        //         editalbeContent.publishedDate.isDeleted = value;
+        //     }
+        // },
         'price': {
             label: '가격',
             isDeleteable: true,
@@ -141,17 +141,17 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
                 editalbeContent.playTime.isDeleted = value;
             }
         },
-        'watchedCnt': {
-            label: '조회수',
-            isDeleteable: true,
-            isDeleted: false,
-            state: watchedCnt,
-            showState: () => setWatchedCnt(content.watchedCnt),
-            setState: setWatchedCnt,
-            setIsDeleted(value: boolean) {
-                editalbeContent.watchedCnt.isDeleted = value;
-            }
-        },
+        // 'watchedCnt': {
+        //     label: '조회수',
+        //     isDeleteable: false,
+        //     isDeleted: false,
+        //     state: watchedCnt,
+        //     showState: () => setWatchedCnt(content.watchedCnt),
+        //     setState: setWatchedCnt,
+        //     setIsDeleted(value: boolean) {
+        //         editalbeContent.watchedCnt.isDeleted = value;
+        //     }
+        // },
     };
 
     const [token, setToken] = useState<string | null>(null);

--- a/src/components/organisms/ScrapEditModal.tsx
+++ b/src/components/organisms/ScrapEditModal.tsx
@@ -127,18 +127,17 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
 
         defaultContentMenu[content.dtype as keyof typeof defaultContentMenu].map((name) => {
             const element = editalbeContent[name as keyof typeof editalbeContent];
-            console.log('state', element.state);
             if (!element.state) {
                 element.isDeleted = true;
-                console.log('not state', element.state);
             }
         });
     }
 
     useEffect(() => {
         setToken(localStorage.getItem('token'));
-        initiateEditableContent();
     }, []);
+
+    initiateEditableContent();
 
     const emptyMemoText = '메모를 입력하세요';
     const createMemo = () => {
@@ -189,18 +188,20 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
         const renderingResult = [];
         for (const key in editalbeContent) {
             const element = editalbeContent[key as keyof typeof editalbeContent];
-            (!element.isDeleted && element.state) && renderingResult.push(
-                <div>
-                    {
-                        < TextArea
-                            labelText={element.label}
-                            defaultValue={content[key as keyof typeof content] as string}
-                            setState={element.setState}
-                            key={element.label + content.scrapId}
-                            isDeleteable={element.isDeleteable}
-                        />
-                    }
-                </div>);
+            console.log('notDeleted', element.isDeleted);
+            (!element.isDeleted && element.state)
+                && renderingResult.push(
+                    <div>
+                        {
+                            < TextArea
+                                labelText={element.label}
+                                defaultValue={content[key as keyof typeof content] as string}
+                                setState={element.setState}
+                                key={element.label + content.scrapId}
+                                isDeleteable={element.isDeleteable}
+                            />
+                        }
+                    </div>);
         }
 
         return renderingResult;
@@ -210,16 +211,18 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
         const renderingResult = [];
         for (const key in editalbeContent) {
             const element = editalbeContent[key as keyof typeof editalbeContent];
-            element.isDeleted && renderingResult.push(
-                <div>
-                    {
-                        <AddableElement
-                            elementTitle={element.label}
-                            onClick={() => element.isDeleted = false}
-                        />
-                    }
-                </div>
-            );
+            console.log('deleted', element.isDeleted);
+            element.isDeleted
+                && renderingResult.push(
+                    <div>
+                        {
+                            <AddableElement
+                                elementTitle={element.label}
+                                onClick={() => element.isDeleted = false}
+                            />
+                        }
+                    </div>
+                );
         }
 
         return renderingResult;

--- a/src/components/organisms/ScrapEditModal.tsx
+++ b/src/components/organisms/ScrapEditModal.tsx
@@ -6,27 +6,11 @@ import Button from '../atoms/DefaultButton';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import MemoTextArea from '../molcules/MemoTextArea';
 import { EDIT_sCRAP_URL } from '../../secret';
+import { contentProps } from './ScrapCard';
 
 interface ScrapEditModalProps {
     hideScrapEditModal: () => void,
-    content: {
-        title?: string,
-        description?: string,
-        siteName?: string,
-        author?: string,
-        blogName?: string,
-        publishedDate?: string,
-        price?: string,
-        channelName?: string,
-        playTime?: string,
-        watchedCnt?: string,
-        memoList?: {
-            memoId: number,
-            memoImageURL?: string,
-            memoText?: string,
-        }[],
-        scrapId: number,
-    },
+    content: contentProps['content'],
     setError: Dispatch<SetStateAction<Partial<null | string>>>,
 }
 
@@ -49,16 +33,12 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
         memoText?: string,
     }[] | undefined>(content.memoList);
 
-    const [token, setToken] = useState<string | null>(null);
-    useEffect(() => {
-        setToken(localStorage.getItem('token'));
-    }, []);
-
     const editalbeContent = [
         {
             name: 'title',
             label: '제목',
             isDeleteable: true,
+            isDeleted: false,
             state: title,
             showState: () => { setTitle(content.title) },
             setState: setTitle,
@@ -67,6 +47,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             name: 'description',
             label: '설명',
             isDeleteable: true,
+            isDeleted: false,
             state: description,
             showState: () => setDescription(content.description),
             setState: setDescription,
@@ -75,6 +56,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             name: 'siteName',
             label: '사이트명',
             isDeleteable: true,
+            isDeleted: false,
             state: siteName,
             showState: () => setSiteName(content.siteName),
             setState: setSiteName,
@@ -83,6 +65,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             name: 'author',
             label: '저자',
             isDeleteable: true,
+            isDeleted: false,
             state: author,
             showState: () => setAuthor(content.author),
             setState: setAuthor,
@@ -91,6 +74,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             name: 'blogName',
             label: '블로그명',
             isDeleteable: true,
+            isDeleted: false,
             state: blogName,
             showState: () => setBlogName(content.blogName),
             setState: setBlogName,
@@ -99,6 +83,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             name: 'publishedDate',
             label: '게시일',
             isDeleteable: true,
+            isDeleted: false,
             state: publishedDate,
             showState: () => setPublishedDate(content.publishedDate),
             setState: setPublishedDate,
@@ -107,6 +92,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             name: 'price',
             label: '가격',
             isDeleteable: true,
+            isDeleted: false,
             state: price,
             showState: () => setPrice(content.price),
             setState: setPrice,
@@ -115,6 +101,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             name: 'channelName',
             label: '채널명',
             isDeleteable: true,
+            isDeleted: false,
             state: channelName,
             showState: () => setChannelName(content.channelName),
             setState: setChannelName,
@@ -123,6 +110,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             name: 'playTime',
             label: '영상 길이',
             isDeleteable: true,
+            isDeleted: false,
             state: playTime,
             showState: () => setPlayTime(content.playTime),
             setState: setPlayTime,
@@ -131,11 +119,18 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             name: 'watchedCnt',
             label: '조회수',
             isDeleteable: true,
+            isDeleted: false,
             state: watchedCnt,
             showState: () => setWatchedCnt(content.watchedCnt),
             setState: setWatchedCnt,
         },
     ];
+
+    const [token, setToken] = useState<string | null>(null);
+    useEffect(() => {
+        setToken(localStorage.getItem('token'));
+
+    }, []);
 
     const emptyMemoText = '메모를 입력하세요';
     const createMemo = () => {
@@ -159,7 +154,9 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
         //    console.log(memo.memoImageURL || (memo.memoText && memo.memoText.length > 0));
         // })
 
-        content = { ...content, memoList: memos }
+        if (memos) {
+            content = { ...content, memoList: memos }
+        }
 
         const url = EDIT_sCRAP_URL;
         token &&

--- a/src/components/organisms/ScrapEditModal.tsx
+++ b/src/components/organisms/ScrapEditModal.tsx
@@ -6,7 +6,7 @@ import Button from '../atoms/DefaultButton';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import MemoTextArea from '../molcules/MemoTextArea';
 import { EDIT_sCRAP_URL } from '../../secret';
-import { contentProps } from './ScrapCard';
+import { contentProps } from '../../types/ContentType';
 
 interface ScrapEditModalProps {
     hideScrapEditModal: () => void,

--- a/src/components/organisms/ScrapEditModal.tsx
+++ b/src/components/organisms/ScrapEditModal.tsx
@@ -125,14 +125,19 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
             video: ['title', 'description', 'siteName', 'channelName', 'playTime', 'watchedCnt', 'publishedDate'],
         };
 
-        // defaultContentMenu[content.dtype as keyof typeof defaultContentMenu].map((name) => {
-        //     if (editalbeContent)
-        // })
+        defaultContentMenu[content.dtype as keyof typeof defaultContentMenu].map((name) => {
+            const element = editalbeContent[name as keyof typeof editalbeContent];
+            console.log('state', element.state);
+            if (!element.state) {
+                element.isDeleted = true;
+                console.log('not state', element.state);
+            }
+        });
     }
 
     useEffect(() => {
         setToken(localStorage.getItem('token'));
-
+        initiateEditableContent();
     }, []);
 
     const emptyMemoText = '메모를 입력하세요';
@@ -184,7 +189,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
         const renderingResult = [];
         for (const key in editalbeContent) {
             const element = editalbeContent[key as keyof typeof editalbeContent];
-            !element.isDeleted && renderingResult.push(
+            (!element.isDeleted && element.state) && renderingResult.push(
                 <div>
                     {
                         < TextArea
@@ -210,7 +215,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
                     {
                         <AddableElement
                             elementTitle={element.label}
-                            onClick={element.showState}
+                            onClick={() => element.isDeleted = false}
                         />
                     }
                 </div>

--- a/src/components/templates/OtherTemplate.tsx
+++ b/src/components/templates/OtherTemplate.tsx
@@ -1,7 +1,7 @@
 import ExistOtherScrapContainer from '../organisms/ExistOtherScrapContainer';
 import ScrapListHeader from '../molcules/ScrapListHeader';
 import EmptyScrapContainer from '../organisms/EmptyScrapContainer';
-import { contentProps } from '../organisms/ScrapCard';
+import { contentProps } from '../../types/ContentType';
 
 interface OtherTemplateProps {
     others: contentProps['content'][],

--- a/src/stories/ScrapEditModal.stories.ts
+++ b/src/stories/ScrapEditModal.stories.ts
@@ -25,10 +25,14 @@ export const defaultScrapEditModal:Story = {
             },
             {
                 memoId: 30,
-                memoImageURL: 'https://cdn.011st.com/11dims/resize/600x600/quality/75/11src/dl/v2/6/4/9/6/6/1/hggNr/2066649661_148653812.jpg',
+                memoImageUrl: 'https://cdn.011st.com/11dims/resize/600x600/quality/75/11src/dl/v2/6/4/9/6/6/1/hggNr/2066649661_148653812.jpg',
             },
             ],
-            scrapId: 0
+            scrapId: 0,
+            pageUrl: 'www.naver.com',
+            thumbnailUrl: '',
+            dtype: 'product',
+
         }
     }
 }

--- a/src/types/ContentType.ts
+++ b/src/types/ContentType.ts
@@ -1,0 +1,28 @@
+export interface contentProps {
+    content: {
+        pageUrl: string,
+        title?: string,
+        description?: string,
+        thumbnailUrl?: string,
+        scrapCreatedDate?: string,
+        scrapId: number,
+        memoList: {
+            memoId: number,
+            memoImageUrl?: string,
+            memoText?: string,
+        }[],
+        siteName?: string,
+        author?: string,
+        authorImageUrl?: string,
+        blogName?: string,
+        publishedDate?: string,
+        price?: string,
+        channelImageUrl?: string,
+        channelName?: string,
+        embedUrl?: string,
+        genre?: string,
+        playTime?: string,
+        watchedCnt?: string,
+        dtype: string,
+    }
+}


### PR DESCRIPTION
## 개요
- DAD-615 : 편집하기로 삭제 후 다시 편집하기 열었을 때 내용 사라지는 오류 개선

## 작업사항
- editableContent에서 isDeleted를 통해 기본적으로 존재해야 하는 대상인데 삭제가 되어 없는 값인 지를 표현함.
- 화면에 렌더링이 되기 이전에 각 isDeleted를 업데이트함
- 화면 렌더링 시 isDeleted를 바탕으로 content 렌더링과 삭제된 content 렌더링을 진행
- setter를 통해 해당 대상을 null로 변경하거나 빈 문자열로 변경하면 자동으로 isDeleted 설정이 변경됨

## 변경로직(Optional)
- isDeleted 요소 추가 및 isDeleted 변경할 수 있는 함수 추가
- editableContent를 배열에서 object로 변경하고, 해당 배열이 렌더링될 수 있도록 JSX에서 렌더링하던 기존 코드를 별도의 함수로 빼냄

## 추후 작업할 내용
- 조회수와 날짜의 타입이 변경되었으므로 이를 반영하기 -> 추후 논의를 통해 각 기본값 설정과 edittext 수정하기/삭제하기 여부, editText 형태 결정해야 함
- 모달을 추상화해야 함 -> 오버레이와 close에 대한 동일한 동작을 할 수 있음, compound pattern 추가로 공부하여 적용할 것
- 추상화한 모달의 위치를 상단으로 변경하여 모달을 닫거나 여는 변경사항이 생기면 화면이 렌더링되도록 구성 -> props drilling이 많아 전역 상태관리 툴 적용 필요