### PR TITLE
[DAD-601] 날짜 데이터 계산 및 렌더링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/material": "^5.13.6",
         "@mui/styled-engine-sc": "^5.12.0",
         "@react-oauth/google": "^0.11.0",
+        "dayjs": "^1.11.9",
         "notistack": "^3.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -10953,6 +10954,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
+      "integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA=="
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@mui/material": "^5.13.6",
     "@mui/styled-engine-sc": "^5.12.0",
     "@react-oauth/google": "^0.11.0",
+    "dayjs": "^1.11.9",
     "notistack": "^3.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/molcules/ArticleScrapCard.tsx
+++ b/src/components/molcules/ArticleScrapCard.tsx
@@ -11,6 +11,7 @@ import ColumnContainer from '../atoms/ColumnContainer';
 import defaultImage from '../../assets/images/Avatar.png';
 import MoreIcon from '../../assets/icons/MoreVerticalIcon.png';
 import theme from '../../assets/styles/theme';
+import { getTimeDiff } from '../../hooks/useCalculateDateDiff';
 
 interface ArticleScrapCardProps {
     content: contentProps['content'],
@@ -19,6 +20,8 @@ interface ArticleScrapCardProps {
 }
 
 function ArticleScrapCard({ content, showMemoCreateModal, showTooltip }: ArticleScrapCardProps) {
+    const articleContent = { ...content };
+
 
     return (
         <CardWrapper
@@ -41,7 +44,7 @@ function ArticleScrapCard({ content, showMemoCreateModal, showTooltip }: Article
                         </ColumnContainer>
                     </RowContainer>
                 }
-                {content.publishedDate && <DefaultTypography>{content.publishedDate}</DefaultTypography>}
+                {content.publishedDate && <DefaultTypography>{getTimeDiff(content.publishedDate)}</DefaultTypography>}
             </RowContainer>
             {content.description && <DefaultTypography>{content.description}</DefaultTypography>}
             {content.memoList?.map(memo => {

--- a/src/components/molcules/VideoScrapCard.tsx
+++ b/src/components/molcules/VideoScrapCard.tsx
@@ -11,6 +11,7 @@ import ColumnContainer from '../atoms/ColumnContainer';
 import MoreIcon from '../../assets/icons/MoreVerticalIcon.png';
 import theme from '../../assets/styles/theme';
 import defaultImage from '../../assets/images/Avatar.png';
+import { getTimeDiff } from '../../hooks/useCalculateDateDiff';
 
 interface VideoScrapCardProps {
     content: contentProps['content'],
@@ -54,7 +55,9 @@ function VideoScrapCard({ content, showMemoCreateModal, showTooltip }: VideoScra
                         <>
                             {menu.content &&
                                 <ColumnContainer style={{ alignItems: 'center', flex: '1' }}>
-                                    <EmpasizedTypography>{menu.content}</EmpasizedTypography>
+                                    <EmpasizedTypography>{
+                                        typeof (menu.content) === 'number' ? getTimeDiff(menu.content) : menu.content
+                                    }</EmpasizedTypography>
                                     <DefaultTypography>{menu.title}</DefaultTypography>
                                 </ColumnContainer>
                             }

--- a/src/components/organisms/ExistListScrapContainer.tsx
+++ b/src/components/organisms/ExistListScrapContainer.tsx
@@ -6,34 +6,10 @@ import { CircularProgress } from "@mui/material"
 import ScrapCard from "./ScrapCard"
 import useInfiniteScroll from "../../hooks/useInfiniteScroll"
 import theme from "../../assets/styles/theme"
+import { contentProps } from "../../types/ContentType"
 
 interface ExistListScrapContainerProps {
-    contents: {
-        pageUrl: string,
-        title: string,
-        description: string,
-        thumbnailUrl: string,
-        scrapCreatedDate: string,
-        scrapId: number,
-        memoList: [{
-            memoId: number,
-            memoImageURL?: string,
-            memoText?: string,
-        }],
-        siteName: string,
-        author: string,
-        authorImageUrl: string,
-        blogName: string,
-        publishedDate: string,
-        price: string,
-        channelImageUrl: string,
-        channelName: string,
-        embedUrl: string,
-        genre: string,
-        playTime: string,
-        watchedCnt: string,
-        dtype: string,
-    }[],
+    contents: contentProps['content'][]
     isFetching: boolean,
     setIsFetching: (isFetching: boolean) => void,
 }

--- a/src/components/organisms/ScrapEditModal.tsx
+++ b/src/components/organisms/ScrapEditModal.tsx
@@ -22,7 +22,7 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
     const [siteName, setSiteName] = useState<string | undefined | null>(content.siteName);
     const [author, setAuthor] = useState<string | undefined | null>(content.author);
     const [blogName, setBlogName] = useState<string | undefined | null>(content.blogName);
-    const [publishedDate, setPublishedDate] = useState<string | undefined | null>(content.publishedDate);
+    const [publishedDate, setPublishedDate] = useState<number | undefined | null>(content.publishedDate);
     const [price, setPrice] = useState<string | undefined | null>(content.price);
     const [channelName, setChannelName] = useState<string | undefined | null>(content.channelName);
     const [playTime, setPlayTime] = useState<string | undefined | null>(content.playTime);

--- a/src/hooks/useCalculateDateDiff.ts
+++ b/src/hooks/useCalculateDateDiff.ts
@@ -1,0 +1,41 @@
+import dayjs, {Dayjs} from 'dayjs';
+import duration, {Duration} from 'dayjs/plugin/duration';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+dayjs.extend(duration);
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+function changeUnixTimeToDate(publishedDate: number) {
+    const unixTime = dayjs.unix(publishedDate);
+    const publishedDateInDate = unixTime.tz().format('YYYY-MM-DD HH:mm:ss Z');
+    return publishedDateInDate;
+}
+
+export function getTimeDiff(publishedDate: number): string {
+    const publishedDateInDate = changeUnixTimeToDate(publishedDate);
+    const timeDiffDuration: Duration = dayjs.duration(dayjs().diff(publishedDateInDate));
+    const yearDiff: number = parseInt(timeDiffDuration.format('Y'));
+    const monthDiff: number = parseInt(timeDiffDuration.format('M'));
+    const dateDiff: number = parseInt(timeDiffDuration.format('D'));
+    const hourDiff: number = parseInt(timeDiffDuration.format('H'));
+    const minuteDiff: number = parseInt(timeDiffDuration.format('m'));
+    const secondDiff: number = parseInt(timeDiffDuration.format('s'));
+
+    if (yearDiff > 0) {
+        return `${yearDiff}년 전`
+    } else if (monthDiff > 0) {
+        return `${monthDiff}달 전`
+    } else if (dateDiff > 0) {
+        return `${dateDiff}일 전`
+    } else if (hourDiff > 0) {
+        return `${hourDiff}시간 전`
+    } else if (minuteDiff > 0) {
+        return `${minuteDiff}분 전`
+    } else if (secondDiff > 0) {
+        return `${secondDiff}초 전`
+    } else {
+        return ''
+    }
+}

--- a/src/types/ContentType.ts
+++ b/src/types/ContentType.ts
@@ -15,7 +15,7 @@ export interface contentProps {
         author?: string,
         authorImageUrl?: string,
         blogName?: string,
-        publishedDate?: string,
+        publishedDate?: number,
         price?: string,
         channelImageUrl?: string,
         channelName?: string,


### PR DESCRIPTION
## 개요
- DAD-601 : 날짜 데이터 계산 및 렌더링

## 작업사항
- unixtime으로 들어오는 입력을 date로 변경
- 해당 date를 dayjs를 사용하여 현재와의 시간 차이 계산
- 필요한 컴포넌트(아티클 카드와 비디오 카드)에 적용

## 변경로직(Optional)
- 자주 쓰이는 타입 별도로 분리 후 import하여 적용(content)

## 추후 적용할 내용
- 현재 date 계산이 호스트의 위치에 따라 반영되고 있는지 테스트 코드 작성
- 시간 차이 string으로 반환하는 함수 로직 리팩토링

## 참고한 링크