### PR TITLE
[DAD-630] 설명 이상 출력 해결

### DIFF
--- a/src/components/organisms/ScrapCard.tsx
+++ b/src/components/organisms/ScrapCard.tsx
@@ -98,6 +98,7 @@ function ScrapCard({ content }: contentProps) {
 const CardContainer = styled.div`
     position: relative;
     border-radius: 4px;
+    word-break: break-all;
 `
 
 const Overlay = styled.div`

--- a/src/components/organisms/ScrapEditModal.tsx
+++ b/src/components/organisms/ScrapEditModal.tsx
@@ -141,17 +141,17 @@ function ScrapEditModal({ hideScrapEditModal, content, setError }: ScrapEditModa
                 editalbeContent.playTime.isDeleted = value;
             }
         },
-        // 'watchedCnt': {
-        //     label: '조회수',
-        //     isDeleteable: false,
-        //     isDeleted: false,
-        //     state: watchedCnt,
-        //     showState: () => setWatchedCnt(content.watchedCnt),
-        //     setState: setWatchedCnt,
-        //     setIsDeleted(value: boolean) {
-        //         editalbeContent.watchedCnt.isDeleted = value;
-        //     }
-        // },
+        'watchedCnt': {
+            label: '조회수',
+            isDeleteable: false,
+            isDeleted: false,
+            state: watchedCnt,
+            showState: () => setWatchedCnt(content.watchedCnt),
+            setState: setWatchedCnt,
+            setIsDeleted(value: boolean) {
+                editalbeContent.watchedCnt.isDeleted = value;
+            }
+        },
     };
 
     const [token, setToken] = useState<string | null>(null);


### PR DESCRIPTION
## 개요
- DAD-630 : 설명 영역보다 긴 단어가 설명에 들어가면 해당 영역을 넘어서 그려지는 오류 해결
- DAD-625 : 영상 수정하기 모달 오류 해결

## 작업사항
- word-break 사용

## 추후 찾아볼 내용
- 이후 더보기 기능을 구현하기 위해서 white-space: no-wrap이 필요하다고 하는데 둘의 기능이 상충되진 않는지 찾아볼 것 (해당 기능을 아직 구현하지 않은 이유는 더보기를 구현하기 위해 제공하는 CSS 기능이 몇몇 브라우저에서는 지원하지 않아 다른 방법을 찾아볼 예정)