### PR TITLE
[DAD-795] 타입스크립트(unusedParameters) 오류 수정

### DIFF
--- a/src/components/atoms/CategoryItem/IconButtonListElement.tsx
+++ b/src/components/atoms/CategoryItem/IconButtonListElement.tsx
@@ -108,7 +108,7 @@ export function IconButtonListElement({ content }: IconButtonListElementProps) {
                 </div>
             </RowContainer>
             {isScrapEditModalVisible && <ScrapEditModal hideScrapEditModal={hideScrapEditModal} content={content} setError={setError} />}
-            {isScrapDeleteModalVisible && <ScrapDeleteModal hideScrapDeleteModal={hideScrapDeleteModal} scrapId={scrapId} setError={setError} />}
+            {isScrapDeleteModalVisible && <ScrapDeleteModal hideScrapDeleteModal={hideScrapDeleteModal} scrapId={scrapId} />}
             {(isScrapEditModalVisible || isScrapDeleteModalVisible)
                 && <Overlay onClick={
                     (e) => {

--- a/src/components/organisms/ScrapCard.tsx
+++ b/src/components/organisms/ScrapCard.tsx
@@ -94,7 +94,7 @@ function ScrapCard({ content }: contentProps) {
             {matchCardType(content.dtype)}
             {isTooltipVisible && <Tooltip contents={scrapCardMenu} color={theme.color.background_color} />}
             {isScrapEditModalVisible && <ScrapEditModal hideScrapEditModal={hideScrapEditModal} content={content} setError={setError} />}
-            {isScrapDeleteModalVisible && <ScrapDeleteModal hideScrapDeleteModal={hideScrapDeleteModal} scrapId={content.scrapId} setError={setError} />}
+            {isScrapDeleteModalVisible && <ScrapDeleteModal hideScrapDeleteModal={hideScrapDeleteModal} scrapId={content.scrapId} />}
             {(isScrapEditModalVisible || isScrapDeleteModalVisible || isMemoCreateModalVisible) && <Overlay />}
             {isMemoCreateModalVisible && <MemoCreateModal hideMemoCreateModal={hideMemoCreateModal} scrapId={content.scrapId} setError={setError} />}
             {error && <ErrorHandler error={error} setError={setError} />}

--- a/src/components/organisms/ScrapDeleteModal.tsx
+++ b/src/components/organisms/ScrapDeleteModal.tsx
@@ -12,39 +12,13 @@ import { useDeleteScrap, usePostCreateScrap } from '../../api/scrap';
 interface ScrapDeleteModalProps {
     hideScrapDeleteModal: () => void,
     scrapId: number,
-    setError: Dispatch<SetStateAction<Partial<null | string>>>,
 }
 
-function ScrapDeleteModal({ hideScrapDeleteModal, scrapId, setError }: ScrapDeleteModalProps) {
+function ScrapDeleteModal({ hideScrapDeleteModal, scrapId }: ScrapDeleteModalProps) {
     const [token, setToken] = useState<string | null>(null);
     useEffect(() => {
         setToken(localStorage.getItem('token'));
     }, []);
-
-    // function deleteScrap() {
-    //     const url = DELETE_SCRAP_URL + `/${scrapId}`;
-    //     token &&
-    //         fetch(url, {
-    //             method: "DELETE",
-    //             headers: {
-    //                 "Content-Type": "application/json",
-    //                 "X-AUTH-TOKEN": token,
-    //             },
-    //         }).then((response) => {
-    //             return response.json().then(body => {
-    //                 if (response.ok) {
-    //                     return body;
-    //                 } else {
-    //                     throw new Error(body.resultCode);
-    //                 }
-    //             })
-    //         })
-    //             .then(() => {
-    //                 useDefaultSnackbar('스크랩이 삭제되었습니다.', 'success');
-    //                 hideScrapDeleteModal();
-    //             })
-    //             .catch(err => setError(err.message));
-    // }
 
     const { mutate, isLoading, isSuccess, isError } = useDeleteScrap();
 


### PR DESCRIPTION
## 개요
- DAD-795

## 작업사항
- 타입스크립트 오류 수정 -> 사용하지 않는 parameter 관련 코드 제거

## 추후 작업할 내용
- ts config에 noUnusedLocals는 현재 꺼두었는데, 바람직하지 않음 -> true로 바꾸고 사용하지 않는 변수는 모두 제거할 것