### PR TITLE
[DAD-874] fix: 검색 결과 없을 경우 emptyScrapContainer 보이기 설정

### DIFF
--- a/src/components/templates/ColumnListTemplate.tsx
+++ b/src/components/templates/ColumnListTemplate.tsx
@@ -1,13 +1,16 @@
-import { useGetScrapByType } from "@/api/scrap";
-import { useGetScrapSearchResultByType } from "@/api/search";
-import MoveToPageMobileModal from "@/components/atoms/Modal/MoveToPageMobileModal";
-import CategoryInfo from "@/components/organisms/ExistCategoryScrapContainer/CategoryInfo";
-import CategoryList from "@/components/organisms/ExistCategoryScrapContainer/CategoryList";
-import { useSelectedScrap } from "@/hooks/useSelectedScrap";
 import { Box, CircularProgress } from "@mui/material";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useSearchParams } from "react-router-dom";
 import styled from "styled-components";
+
+import { useGetScrapByType } from "@/api/scrap";
+import { useGetScrapSearchResultByType } from "@/api/search";
+import { useSelectedScrap } from "@/hooks/useSelectedScrap";
+
+import MoveToPageMobileModal from "@/components/atoms/Modal/MoveToPageMobileModal";
+import EmptyScrapContainer from "@/components/organisms/EmptyScrapContainer";
+import CategoryInfo from "@/components/organisms/ExistCategoryScrapContainer/CategoryInfo";
+import CategoryList from "@/components/organisms/ExistCategoryScrapContainer/CategoryList";
 
 function ColumnListTemplate({ type }: { type: string }) {
     const token = localStorage.getItem('token');
@@ -56,6 +59,10 @@ function ColumnListTemplate({ type }: { type: string }) {
                 }}
             />
         )
+    }
+
+    if (data?.pages[0].data.content.length === 0) {
+        return <EmptyScrapContainer />
     }
 
     return (

--- a/src/components/templates/MasonryListTemplate.tsx
+++ b/src/components/templates/MasonryListTemplate.tsx
@@ -1,13 +1,16 @@
-import { useGetScrapByType } from '@/api/scrap';
-import { useGetScrapSearchResultByType } from '@/api/search';
-import ScrapCard from '@/components/organisms/ScrapCard';
-import { contentProps } from '@/types/ContentType';
 import { Masonry } from '@mui/lab';
 import { CircularProgress } from '@mui/material';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import InfiniteScroll from 'react-infinite-scroller';
 import { useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
+
+import { useGetScrapByType } from '@/api/scrap';
+import { useGetScrapSearchResultByType } from '@/api/search';
+import { contentProps } from '@/types/ContentType';
+
+import EmptyScrapContainer from '@/components/organisms/EmptyScrapContainer';
+import ScrapCard from '@/components/organisms/ScrapCard';
 
 function MasonryListTemplate({ type }: { type: string }) {
     const token = localStorage.getItem('token');
@@ -49,6 +52,10 @@ function MasonryListTemplate({ type }: { type: string }) {
                 }}
             />
         )
+    }
+
+    if (data?.pages[0].data.content.length === 0) {
+        return <EmptyScrapContainer />
     }
 
     return (


### PR DESCRIPTION
## 개요
- DAD-874

## 작업사항
- 검색 결과 개수에 따라 다른 템플릿 return 하도록 변경 (= 아티클, 비디오, 상품 페이지에서 검색 결과 없을 경우 오류 해결)

## 추후 작업할 내용
스크랩 개수를 통해 미리 listTemplate 형태를 지정하던 형식을 사용하고 있었는데, 해당 판단 위치를 다른 부분으로 아예 옮겨야 할 것 같다.