### PR TITLE
[DAD-891] 유효성 검사 추가

### DIFF
--- a/src/components/atoms/Modal/MemoCreateModalElement.tsx
+++ b/src/components/atoms/Modal/MemoCreateModalElement.tsx
@@ -83,7 +83,7 @@ function MemoCreateModalElement() {
                 <FormHelperText>
                     <Typography
                         variant="h6"
-                        color={theme.color.Gray_060}
+                        color={isValidationSuccess() ? theme.color.Gray_060 : '#f44336'}
                         sx={{
                             fontWeight: '500',
                             lineHeight: '150%',

--- a/src/components/atoms/Modal/MemoCreateModalElement.tsx
+++ b/src/components/atoms/Modal/MemoCreateModalElement.tsx
@@ -5,7 +5,7 @@ import theme from '@/assets/styles/theme';
 import { useModal } from '@/hooks/useModal';
 import { usePostCreateMemo } from '@/api/memo';
 import { useDefaultSnackbar } from '@/hooks/useWarningSnackbar';
-import { MAX_MEMO_LENGTH } from '@/hooks/useValidation';
+import { MAX_MEMO_LENGTH, useIsEntered, useIsLessThanLengthLimitation } from '@/hooks/useValidation';
 
 function MemoCreateModalElement() {
     const [, setToken] = useState<string | null>(null);
@@ -39,14 +39,12 @@ function MemoCreateModalElement() {
         useDefaultSnackbar('메모 생성에 실패하였습니다.', 'error');
     }
 
-    const isLessThanLengthLimitation = (textAreaValue.length <= MAX_MEMO_LENGTH);
-    const isEntered = (textAreaValue.length > 0);
     const validation = () => {
-        if (!isLessThanLengthLimitation) {
+        if (!useIsLessThanLengthLimitation(textAreaValue, MAX_MEMO_LENGTH)) {
             return `최대 ${MAX_MEMO_LENGTH}글자까지만 입력 가능합니다.`;
         }
 
-        if (!isEntered) {
+        if (!useIsEntered(textAreaValue)) {
             return ' ';
         }
 

--- a/src/components/atoms/Modal/MemoCreateModalElement.tsx
+++ b/src/components/atoms/Modal/MemoCreateModalElement.tsx
@@ -47,7 +47,7 @@ function MemoCreateModalElement() {
         }
 
         if (!isEntered) {
-            return '빈 메모는 입력하실 수 없습니다.';
+            return ' ';
         }
 
         return 'success';
@@ -77,13 +77,11 @@ function MemoCreateModalElement() {
                     }}
                     multiline
                     rows={5}
-                    error={!isValidationSuccess()}
-                    autoFocus
                 />
                 <FormHelperText>
                     <Typography
                         variant="h6"
-                        color={isValidationSuccess() ? theme.color.Gray_060 : '#f44336'}
+                        color={theme.color.Gray_060}
                         sx={{
                             fontWeight: '500',
                             lineHeight: '150%',

--- a/src/components/atoms/Modal/MemoCreateModalElement.tsx
+++ b/src/components/atoms/Modal/MemoCreateModalElement.tsx
@@ -5,6 +5,7 @@ import theme from '@/assets/styles/theme';
 import { useModal } from '@/hooks/useModal';
 import { usePostCreateMemo } from '@/api/memo';
 import { useDefaultSnackbar } from '@/hooks/useWarningSnackbar';
+import { MAX_MEMO_LENGTH } from '@/hooks/useValidation';
 
 function MemoCreateModalElement() {
     const [, setToken] = useState<string | null>(null);
@@ -38,7 +39,6 @@ function MemoCreateModalElement() {
         useDefaultSnackbar('메모 생성에 실패하였습니다.', 'error');
     }
 
-    const MAX_MEMO_LENGTH = 1000;
     const isLessThanLengthLimitation = (textAreaValue.length <= MAX_MEMO_LENGTH);
     const isEntered = (textAreaValue.length > 0);
     const validation = () => {

--- a/src/components/atoms/Modal/MemoCreateModalElement.tsx
+++ b/src/components/atoms/Modal/MemoCreateModalElement.tsx
@@ -5,7 +5,7 @@ import theme from '@/assets/styles/theme';
 import { useModal } from '@/hooks/useModal';
 import { usePostCreateMemo } from '@/api/memo';
 import { useDefaultSnackbar } from '@/hooks/useWarningSnackbar';
-import { MAX_MEMO_LENGTH, useIsEntered, useIsLessThanLengthLimitation } from '@/hooks/useValidation';
+import { MAX_MEMO_LENGTH, useIsBlank, useIsEntered, useIsLessThanLengthLimitation } from '@/hooks/useValidation';
 
 function MemoCreateModalElement() {
     const [, setToken] = useState<string | null>(null);
@@ -46,6 +46,10 @@ function MemoCreateModalElement() {
 
         if (!useIsEntered(textAreaValue)) {
             return ' ';
+        }
+
+        if (useIsBlank(textAreaValue)) {
+            return '공백만 입력되었습니다.';
         }
 
         return 'success';

--- a/src/components/atoms/Modal/ScrapCreateModalElement.tsx
+++ b/src/components/atoms/Modal/ScrapCreateModalElement.tsx
@@ -37,10 +37,6 @@ function ScrapCreateModalElement() {
             return '유효하지 않은 URL입니다.';
         }
 
-        if (useIsBlank(textAreaValue)) {
-            return '공백만 입력되었습니다.';
-        }
-
         return 'success';
     }
     const isValidationSuccess = () => validation() === 'success';

--- a/src/components/atoms/Modal/ScrapCreateModalElement.tsx
+++ b/src/components/atoms/Modal/ScrapCreateModalElement.tsx
@@ -6,7 +6,7 @@ import theme from '@/assets/styles/theme';
 import { useModal } from '@/hooks/useModal';
 
 import { LinkIcon } from '@/components/atoms/Icon';
-import { SCRAP_LINK_MAX_LENGTH, useIsValidURL } from '@/hooks/useValidation';
+import { SCRAP_LINK_MAX_LENGTH, useIsBlank, useIsEntered, useIsLessThanLengthLimitation, useIsValidURL, useIsWhiteSpaceExist } from '@/hooks/useValidation';
 
 function ScrapCreateModalElement() {
     const [textAreaValue, setTextAreaValue] = useState('');
@@ -24,21 +24,21 @@ function ScrapCreateModalElement() {
 
     const { mutate } = usePostCreateScrap();
 
-    const isLessThanLengthLimitation = (textAreaValue.length <= SCRAP_LINK_MAX_LENGTH);
-    const iswhiteSpaceExist = (textAreaValue.replace(/\s+/g, '').length !== textAreaValue.length);
-    const isEntered = (textAreaValue.length > 0);
-
     const validation = () => {
-        if (!isLessThanLengthLimitation) {
+        if (!useIsLessThanLengthLimitation(textAreaValue, SCRAP_LINK_MAX_LENGTH)) {
             return `최대 ${SCRAP_LINK_MAX_LENGTH}글자까지만 입력 가능합니다.`;
         }
 
-        if (!isEntered) {
+        if (!useIsEntered(textAreaValue)) {
             return ' ';
         }
 
-        if (iswhiteSpaceExist || !useIsValidURL(textAreaValue)) {
+        if (useIsWhiteSpaceExist(textAreaValue) || !useIsValidURL(textAreaValue)) {
             return '유효하지 않은 URL입니다.';
+        }
+
+        if (useIsBlank(textAreaValue)) {
+            return '공백만 입력되었습니다.';
         }
 
         return 'success';

--- a/src/components/atoms/Modal/ScrapCreateModalElement.tsx
+++ b/src/components/atoms/Modal/ScrapCreateModalElement.tsx
@@ -6,7 +6,7 @@ import theme from '@/assets/styles/theme';
 import { useModal } from '@/hooks/useModal';
 
 import { LinkIcon } from '@/components/atoms/Icon';
-import { useIsValidURL } from '@/hooks/useValidation';
+import { SCRAP_LINK_MAX_LENGTH, useIsValidURL } from '@/hooks/useValidation';
 
 function ScrapCreateModalElement() {
     const [textAreaValue, setTextAreaValue] = useState('');
@@ -24,7 +24,6 @@ function ScrapCreateModalElement() {
 
     const { mutate } = usePostCreateScrap();
 
-    const SCRAP_LINK_MAX_LENGTH = 2083;
     const isLessThanLengthLimitation = (textAreaValue.length <= SCRAP_LINK_MAX_LENGTH);
     const iswhiteSpaceExist = (textAreaValue.replace(/\s+/g, '').length !== textAreaValue.length);
     const isEntered = (textAreaValue.length > 0);

--- a/src/components/atoms/Modal/ScrapEditModalElement.tsx
+++ b/src/components/atoms/Modal/ScrapEditModalElement.tsx
@@ -148,7 +148,7 @@ function ScrapEditModalElement() {
         }
 
         if (!useIsEntered(text)) {
-            return ' ';
+            return '내용을 입력해주세요.';
         }
 
         if (useIsBlank(text)) {
@@ -156,6 +156,22 @@ function ScrapEditModalElement() {
         }
 
         return 'success';
+    }
+
+    function checkIsEveryValidationSuccessed() {
+        for (const key in editalbeContent) {
+            const element = editalbeContent[key as keyof typeof editalbeContent];
+            if (!element.isDeleted
+                && typeof (element.state) === 'string'
+                && validation({
+                    text: element.state,
+                    textLimitation: element.limitation
+                }) !== 'success') {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     const [token, setToken] = useState<string | null>(null);
@@ -374,6 +390,7 @@ function ScrapEditModalElement() {
                     removeSelectedScrap();
                     editScrap()
                 }}
+                disabled={!checkIsEveryValidationSuccessed()}
             >
                 변경하기
             </Button>

--- a/src/components/atoms/Modal/ScrapEditModalElement.tsx
+++ b/src/components/atoms/Modal/ScrapEditModalElement.tsx
@@ -4,7 +4,8 @@ import { MinusCircleIcon, PlusCircleIcon } from "@/components/atoms/Icon";
 import ThumbnailImage from "@/components/atoms/ThumbnailImage";
 import { useModal } from "@/hooks/useModal";
 import { useSelectedScrap } from "@/hooks/useSelectedScrap";
-import { Box, Button, TextareaAutosize, Typography } from "@mui/material";
+import { MAX_SCRAP_AUTHOR_LENGTH, MAX_SCRAP_BLOGNAME_LENGTH, MAX_SCRAP_CHANNELNAME_LENGTH, MAX_SCRAP_DESCRIPTION_LENGTH, MAX_SCRAP_PRICE_LENGTH, MAX_SCRAP_SITENAME_LENGTH, MAX_SCRAP_TITLE_LENGTH, useIsBlank, useIsEntered, useIsLessThanLengthLimitation } from "@/hooks/useValidation";
+import { Box, Button, FormControl, FormHelperText, TextareaAutosize, Typography } from "@mui/material";
 import { ChangeEvent, useEffect, useState } from "react";
 
 function ScrapEditModalElement() {
@@ -36,6 +37,7 @@ function ScrapEditModalElement() {
             isDeleteable: true,
             isDeleted: false,
             state: title,
+            limitation: MAX_SCRAP_TITLE_LENGTH,
             showState: () => { setTitle(content.title) },
             setState: setTitle,
             setIsDeleted(value: boolean) {
@@ -47,6 +49,7 @@ function ScrapEditModalElement() {
             isDeleteable: true,
             isDeleted: false,
             state: description,
+            limitation: MAX_SCRAP_DESCRIPTION_LENGTH,
             showState: () => setDescription(content.description),
             setState: setDescription,
             setIsDeleted(value: boolean) {
@@ -58,6 +61,7 @@ function ScrapEditModalElement() {
             isDeleteable: true,
             isDeleted: false,
             state: siteName,
+            limitation: MAX_SCRAP_SITENAME_LENGTH,
             showState: () => setSiteName(content.siteName),
             setState: setSiteName,
             setIsDeleted(value: boolean) {
@@ -69,6 +73,7 @@ function ScrapEditModalElement() {
             isDeleteable: true,
             isDeleted: false,
             state: author,
+            limitation: MAX_SCRAP_AUTHOR_LENGTH,
             showState: () => setAuthor(content.author),
             setState: setAuthor,
             setIsDeleted(value: boolean) {
@@ -80,6 +85,7 @@ function ScrapEditModalElement() {
             isDeleteable: true,
             isDeleted: false,
             state: blogName,
+            limitation: MAX_SCRAP_BLOGNAME_LENGTH,
             showState: () => setBlogName(content.blogName),
             setState: setBlogName,
             setIsDeleted(value: boolean) {
@@ -91,6 +97,7 @@ function ScrapEditModalElement() {
             isDeleteable: true,
             isDeleted: false,
             state: price,
+            limitation: MAX_SCRAP_PRICE_LENGTH,
             showState: () => setPrice(content.price),
             setState: setPrice,
             setIsDeleted(value: boolean) {
@@ -102,6 +109,7 @@ function ScrapEditModalElement() {
             isDeleteable: true,
             isDeleted: false,
             state: channelName,
+            limitation: MAX_SCRAP_CHANNELNAME_LENGTH,
             showState: () => setChannelName(content.channelName),
             setState: setChannelName,
             setIsDeleted(value: boolean) {
@@ -113,6 +121,7 @@ function ScrapEditModalElement() {
             isDeleteable: true,
             isDeleted: false,
             state: playTime,
+            limitation: 0,
             showState: () => setPlayTime(content.playTime),
             setState: setPlayTime,
             setIsDeleted(value: boolean) {
@@ -124,6 +133,7 @@ function ScrapEditModalElement() {
             isDeleteable: false,
             isDeleted: false,
             state: watchedCnt,
+            limitation: 0,
             showState: () => setWatchedCnt(content.watchedCnt),
             setState: setWatchedCnt,
             setIsDeleted(value: boolean) {
@@ -131,6 +141,22 @@ function ScrapEditModalElement() {
             }
         },
     };
+
+    const validation = ({ text, textLimitation }: { text: string, textLimitation: number }) => {
+        if (!useIsLessThanLengthLimitation(text, textLimitation)) {
+            return `최대 ${textLimitation}글자까지만 입력 가능합니다.`;
+        }
+
+        if (!useIsEntered(text)) {
+            return ' ';
+        }
+
+        if (useIsBlank(text)) {
+            return '공백만 입력되었습니다.';
+        }
+
+        return 'success';
+    }
 
     const [token, setToken] = useState<string | null>(null);
     function initiateEditableContent() {
@@ -259,23 +285,41 @@ function ScrapEditModalElement() {
                         {element.label}
                     </Typography>
                 </Box>
-                <TextareaAutosize
-                    defaultValue={content[key as keyof typeof content] as string}
-                    style={{
-                        resize: 'none',
-                        background: '#FFF',
-                        border: `1px solid ${theme.color.Gray_040}`,
-                        width: '100%',
-                        boxSizing: 'border-box',
-                        borderRadius: '8px',
-                        padding: '10px',
-                        fontSize: '14px',
-                        fontWeight: '500',
-                        lineHeight: '150%',
-                        color: theme.color.Gray_090,
-                    }}
-                    onChange={e => handleSetValue(e)}
-                />
+                <FormControl>
+                    <TextareaAutosize
+                        defaultValue={content[key as keyof typeof content] as string}
+                        style={{
+                            resize: 'none',
+                            background: '#FFF',
+                            border: `1px solid ${theme.color.Gray_040}`,
+                            width: '100%',
+                            boxSizing: 'border-box',
+                            borderRadius: '8px',
+                            padding: '10px',
+                            fontSize: '14px',
+                            fontWeight: '500',
+                            lineHeight: '150%',
+                            color: theme.color.Gray_090,
+                        }}
+                        onChange={e => handleSetValue(e)}
+                    />
+                    <FormHelperText
+                        sx={{
+                            alignSelf: 'start',
+                            color: '#f44336',
+                        }}
+                    >
+                        {validation({
+                            text: element.state,
+                            textLimitation: element.limitation,
+                        }) !== 'success'
+                            ? validation({
+                                text: element.state,
+                                textLimitation: element.limitation,
+                            })
+                            : ' '}
+                    </FormHelperText>
+                </FormControl>
             </Box>
         )
     }

--- a/src/components/molcules/SearchBar.tsx
+++ b/src/components/molcules/SearchBar.tsx
@@ -6,6 +6,7 @@ import { SearchIcon } from "@/components/atoms/Icon";
 import { useEffect, useRef, useState } from "react";
 import { useGetScrapSearchResultByType } from "@/api/search";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import { useIsBlank } from "@/hooks/useValidation";
 
 function SearchBar({ type }: { type: string }) {
     const [isSearched, setIsSearched] = useState(false);
@@ -34,6 +35,8 @@ function SearchBar({ type }: { type: string }) {
             }
         }
     };
+
+    const isValidationSuccess = () => useIsBlank(searchText) ? false : true;
 
     return (
         <Box
@@ -74,6 +77,7 @@ function SearchBar({ type }: { type: string }) {
                             p: '0',
                             color: theme.color.Gray_070,
                         }}
+                        disabled={!isValidationSuccess()}
                         onClick={isSearched ? buttonInfo.isSearched.action : buttonInfo.isNotSearched.action}
                     >
                         {isSearched ? buttonInfo.isSearched.text : buttonInfo.isNotSearched.text}

--- a/src/hooks/useValidation.test.ts
+++ b/src/hooks/useValidation.test.ts
@@ -1,4 +1,4 @@
-import { useIsValidURL } from '@/hooks/useValidation';
+import { useIsLessThanLengthLimitation, useIsValidURL } from '@/hooks/useValidation';
 import { expect, describe, it } from 'vitest';
 
 describe('validation hook 테스트', () => {
@@ -8,5 +8,10 @@ describe('validation hook 테스트', () => {
         expect(useIsValidURL('https://velog.io/@juanito_y247/React-Query-Devtools')).toBe(true);
         expect(useIsValidURL('www.naver.com')).toBe(false);
         expect(useIsValidURL('https://velog.io/@juhyeon1114/React-%EC%83%81%ED%83%9C%EA%B4%80%EB%A6%AC-%EB%9D%BC%EC%9D%B4%EB%B8%8C%EB%9F%AC%EB%A6%AC-%EB%A6%AC%EB%B7%B0-Zustand-Recoil-Jotai-React-query')).toBe(true);
+    });
+
+    it('useIsLessThanLengthLimitation을 통해 길이 제한이 감지 되는지 검사한다.', () => {
+        expect(useIsLessThanLengthLimitation('1234567890', 10)).toBe(true);
+        expect(useIsLessThanLengthLimitation('1234567890', 9)).toBe(false);
     });
 })

--- a/src/hooks/useValidation.test.ts
+++ b/src/hooks/useValidation.test.ts
@@ -32,4 +32,11 @@ describe('validation hook 테스트', () => {
         expect(useIsEntered(' ')).toBe(true);
         expect(useIsEntered('a')).toBe(true);
     });
+
+    it('useIsWhiteSpaceExist를 통해 공백이 존재하는지 검사한다.', () => {
+        expect(useIsEntered(' ')).toBe(true);
+        expect(useIsEntered('a')).toBe(true);
+        expect(useIsEntered('a ')).toBe(true);
+        expect(useIsEntered(`a\n`)).toBe(true);
+    });
 })

--- a/src/hooks/useValidation.test.ts
+++ b/src/hooks/useValidation.test.ts
@@ -26,4 +26,10 @@ describe('validation hook 테스트', () => {
         expect(useIsBlank(`\n`)).toBe(true);
         expect(useIsBlank(`\t`)).toBe(true);
     });
+
+    it('useIsEntered를 통해 입력이 되었는지 검사한다.', () => {
+        expect(useIsEntered('')).toBe(false);
+        expect(useIsEntered(' ')).toBe(true);
+        expect(useIsEntered('a')).toBe(true);
+    });
 })

--- a/src/hooks/useValidation.test.ts
+++ b/src/hooks/useValidation.test.ts
@@ -1,4 +1,4 @@
-import { useIsLessThanLengthLimitation, useIsValidURL } from '@/hooks/useValidation';
+import { useIsBlank, useIsLessThanLengthLimitation, useIsValidURL } from '@/hooks/useValidation';
 import { expect, describe, it } from 'vitest';
 
 describe('validation hook 테스트', () => {
@@ -13,5 +13,15 @@ describe('validation hook 테스트', () => {
     it('useIsLessThanLengthLimitation을 통해 길이 제한이 감지 되는지 검사한다.', () => {
         expect(useIsLessThanLengthLimitation('1234567890', 10)).toBe(true);
         expect(useIsLessThanLengthLimitation('1234567890', 9)).toBe(false);
+    });
+
+    it('useIsBlank을 통해 공백으로 이루어졌는지 검사한다.', () => {
+        expect(useIsBlank('')).toBe(true);
+        expect(useIsBlank(' ')).toBe(true);
+        expect(useIsBlank('  ')).toBe(true);
+        expect(useIsBlank('  a')).toBe(false);
+        expect(useIsBlank('a  ')).toBe(false);
+        expect(useIsBlank('  a  ')).toBe(false);
+        expect(useIsBlank('a')).toBe(false);
     });
 })

--- a/src/hooks/useValidation.test.ts
+++ b/src/hooks/useValidation.test.ts
@@ -1,4 +1,4 @@
-import { useIsBlank, useIsLessThanLengthLimitation, useIsValidURL } from '@/hooks/useValidation';
+import { useIsBlank, useIsEntered, useIsLessThanLengthLimitation, useIsValidURL } from '@/hooks/useValidation';
 import { expect, describe, it } from 'vitest';
 
 describe('validation hook 테스트', () => {
@@ -23,5 +23,7 @@ describe('validation hook 테스트', () => {
         expect(useIsBlank('a  ')).toBe(false);
         expect(useIsBlank('  a  ')).toBe(false);
         expect(useIsBlank('a')).toBe(false);
+        expect(useIsBlank(`\n`)).toBe(true);
+        expect(useIsBlank(`\t`)).toBe(true);
     });
 })

--- a/src/hooks/useValidation.ts
+++ b/src/hooks/useValidation.ts
@@ -1,5 +1,12 @@
 export const MAX_MEMO_LENGTH = 1000;
 export const SCRAP_LINK_MAX_LENGTH = 2083;
+export const MAX_SCRAP_TITLE_LENGTH = 10;
+export const MAX_SCRAP_DESCRIPTION_LENGTH = 10;
+export const MAX_SCRAP_SITENAME_LENGTH = 10;
+export const MAX_SCRAP_AUTHOR_LENGTH = 10;
+export const MAX_SCRAP_BLOGNAME_LENGTH = 10;
+export const MAX_SCRAP_PRICE_LENGTH = 10;
+export const MAX_SCRAP_CHANNELNAME_LENGTH = 10;
 
 export function useIsValidURL(url: string) {
     try {

--- a/src/hooks/useValidation.ts
+++ b/src/hooks/useValidation.ts
@@ -1,3 +1,5 @@
+export const MAX_MEMO_LENGTH = 1000;
+
 export function useIsValidURL(url: string) {
     try {
         new URL(url);

--- a/src/hooks/useValidation.ts
+++ b/src/hooks/useValidation.ts
@@ -14,3 +14,7 @@ export function useIsLessThanLengthLimitation(text: string, limit: number) {
 export function useIsBlank(text: string) {
     return text.replace(/\s+/g, '').length === 0;
 }
+
+export function useIsEntered(text: string) {
+    return text.length > 0;
+}

--- a/src/hooks/useValidation.ts
+++ b/src/hooks/useValidation.ts
@@ -12,7 +12,7 @@ export function useIsLessThanLengthLimitation(text: string, limit: number) {
 }
 
 export function useIsBlank(text: string) {
-    return text.replace(/\s+/g, '').length === 0;
+    return /^\s*$/.test(text);
 }
 
 export function useIsEntered(text: string) {
@@ -20,5 +20,5 @@ export function useIsEntered(text: string) {
 }
 
 export function useIsWhiteSpaceExist(text: string) {
-    return text.replace(/\s+/g, '').length !== text.length;
+    return /^\S*$/.test(text);
 }

--- a/src/hooks/useValidation.ts
+++ b/src/hooks/useValidation.ts
@@ -18,3 +18,7 @@ export function useIsBlank(text: string) {
 export function useIsEntered(text: string) {
     return text.length > 0;
 }
+
+export function useIsWhiteSpaceExist(text: string) {
+    return text.replace(/\s+/g, '').length !== text.length;
+}

--- a/src/hooks/useValidation.ts
+++ b/src/hooks/useValidation.ts
@@ -1,12 +1,12 @@
 export const MAX_MEMO_LENGTH = 1000;
 export const SCRAP_LINK_MAX_LENGTH = 2083;
-export const MAX_SCRAP_TITLE_LENGTH = 10;
-export const MAX_SCRAP_DESCRIPTION_LENGTH = 10;
-export const MAX_SCRAP_SITENAME_LENGTH = 10;
-export const MAX_SCRAP_AUTHOR_LENGTH = 10;
-export const MAX_SCRAP_BLOGNAME_LENGTH = 10;
-export const MAX_SCRAP_PRICE_LENGTH = 10;
-export const MAX_SCRAP_CHANNELNAME_LENGTH = 10;
+export const MAX_SCRAP_TITLE_LENGTH = 200;
+export const MAX_SCRAP_DESCRIPTION_LENGTH = 1000;
+export const MAX_SCRAP_SITENAME_LENGTH = 100;
+export const MAX_SCRAP_AUTHOR_LENGTH = 100;
+export const MAX_SCRAP_BLOGNAME_LENGTH = 100;
+export const MAX_SCRAP_PRICE_LENGTH = 100;
+export const MAX_SCRAP_CHANNELNAME_LENGTH = 100;
 
 export function useIsValidURL(url: string) {
     try {

--- a/src/hooks/useValidation.ts
+++ b/src/hooks/useValidation.ts
@@ -6,3 +6,7 @@ export function useIsValidURL(url: string) {
         return false;
     }
 }
+
+export function useIsLessThanLengthLimitation(text: string, limit: number) {
+    return text.length <= limit;
+}

--- a/src/hooks/useValidation.ts
+++ b/src/hooks/useValidation.ts
@@ -1,4 +1,5 @@
 export const MAX_MEMO_LENGTH = 1000;
+export const SCRAP_LINK_MAX_LENGTH = 2083;
 
 export function useIsValidURL(url: string) {
     try {

--- a/src/hooks/useValidation.ts
+++ b/src/hooks/useValidation.ts
@@ -10,3 +10,7 @@ export function useIsValidURL(url: string) {
 export function useIsLessThanLengthLimitation(text: string, limit: number) {
     return text.length <= limit;
 }
+
+export function useIsBlank(text: string) {
+    return text.replace(/\s+/g, '').length === 0;
+}


### PR DESCRIPTION
## 개요
- DAD-892 : validation 추가 연결
- DAD-894 : 메모 validation 변경

## 작업사항
- isblank 훅 추가 구현
- 분리한 validation hook들 테스트 코드 작성
- 기존 editText들 validation 분리한 hook으로 변경
- 편집하기 모달 validation 추가 및 disabled 처리 추가 : isBlank, 글자수 제한
- 메모 editText : isblank 검사 추가, error styling 변경
- 검색 : isblank 검사 추가 및 버튼 disabled 처리 추가

## 변경로직(Optional)
- validation 관련 로직 모두 hook으로 분리
- 추가로 글자수 제한 상수도 hook 내에서 상수로 관리하도록 변경

## 고려할 내용
- validation 관련 라이브러리 적용 (React hook form, yup)
- validation에 대한 if문 책임을 hook에서 가지도록 좀 더 자동화하고 싶다
- 스프링의 isBlank와는 달리 null같은 타입에 대한 검사는 안 됨(어차피 editText의 글자이기 때문에 string 타입 보장됨)