### PR TITLE
[DAD-902] fix: 유효하지 않은 url 검사 hook boolean 반대로 적용 오류 수정

### DIFF
--- a/src/components/atoms/Modal/ScrapCreateModalElement.tsx
+++ b/src/components/atoms/Modal/ScrapCreateModalElement.tsx
@@ -33,7 +33,7 @@ function ScrapCreateModalElement() {
             return ' ';
         }
 
-        if (!useIsWhiteSpaceExist(textAreaValue) || !useIsValidURL(textAreaValue)) {
+        if (useIsWhiteSpaceExist(textAreaValue) || !useIsValidURL(textAreaValue)) {
             return '유효하지 않은 URL입니다.';
         }
 

--- a/src/components/atoms/Modal/ScrapCreateModalElement.tsx
+++ b/src/components/atoms/Modal/ScrapCreateModalElement.tsx
@@ -33,7 +33,7 @@ function ScrapCreateModalElement() {
             return ' ';
         }
 
-        if (useIsWhiteSpaceExist(textAreaValue) || !useIsValidURL(textAreaValue)) {
+        if (!useIsWhiteSpaceExist(textAreaValue) || !useIsValidURL(textAreaValue)) {
             return '유효하지 않은 URL입니다.';
         }
 

--- a/src/hooks/useValidation.test.ts
+++ b/src/hooks/useValidation.test.ts
@@ -1,4 +1,4 @@
-import { useIsBlank, useIsEntered, useIsLessThanLengthLimitation, useIsValidURL } from '@/hooks/useValidation';
+import { useIsBlank, useIsEntered, useIsLessThanLengthLimitation, useIsValidURL, useIsWhiteSpaceExist } from '@/hooks/useValidation';
 import { expect, describe, it } from 'vitest';
 
 describe('validation hook 테스트', () => {
@@ -34,9 +34,11 @@ describe('validation hook 테스트', () => {
     });
 
     it('useIsWhiteSpaceExist를 통해 공백이 존재하는지 검사한다.', () => {
-        expect(useIsEntered(' ')).toBe(true);
-        expect(useIsEntered('a')).toBe(true);
-        expect(useIsEntered('a ')).toBe(true);
-        expect(useIsEntered(`a\n`)).toBe(true);
+        expect(useIsWhiteSpaceExist(' ')).toBe(true);
+        expect(useIsWhiteSpaceExist('a')).toBe(false);
+        expect(useIsWhiteSpaceExist('a ')).toBe(true);
+        expect(useIsWhiteSpaceExist(`a\n`)).toBe(true);
+        expect(useIsWhiteSpaceExist(`\n\n`)).toBe(true);
+        expect(useIsWhiteSpaceExist(`\t`)).toBe(true);
     });
 })

--- a/src/hooks/useValidation.ts
+++ b/src/hooks/useValidation.ts
@@ -30,5 +30,5 @@ export function useIsEntered(text: string) {
 }
 
 export function useIsWhiteSpaceExist(text: string) {
-    return /^\S*$/.test(text);
+    return !/^\S*$/.test(text);
 }


### PR DESCRIPTION
## 개요
- DAD-902

## 작업사항 설명
- 유효하지 않은 url 검사로 공백 존재 여부 검사 및 url 형식(https/http로 시작하는지) 검사를 진행 중
- 공백 존재 여부 검사(useIsWhiteSpaceExist)의 결과가 원하는 값의 반대로 설정되어 있었음
- 테스트 코드도 다른 hook을 테스트하고 있어서 알지 못했음
=> 공백 존재 여부 검사 결과 반대로 뒤집기 + if문 판단도 반대로 뒤집기 + 테스트 코드 작성하여 확인해보기