### PR TITLE
[DAD-924] 보드 목록에서 개수 조회 구현

### DIFF
--- a/src/api/board.ts
+++ b/src/api/board.ts
@@ -73,6 +73,7 @@ export const usePostCreateBoard = () => {
     return useMutation(fetchPostCreateBoard, {
         onSuccess: () => {
             queryClient.invalidateQueries(['boards']);
+            queryClient.invalidateQueries(['boardListCount']);
             useDefaultSnackbar('보드가 생성되었습니다', 'success');
         },
         onError: (error) => {

--- a/src/api/count.ts
+++ b/src/api/count.ts
@@ -1,4 +1,4 @@
-import { GET_OTHER_SCRAP_URL, GET_LIST_SCRAP_URL, GET_ARTICLE_SCRAP_URL, GET_PRODUCT_SCRAP_URL, GET_VIDEO_SCRAP_URL } from "@/secret";
+import { GET_OTHER_SCRAP_URL, GET_LIST_SCRAP_URL, GET_ARTICLE_SCRAP_URL, GET_PRODUCT_SCRAP_URL, GET_VIDEO_SCRAP_URL, GET_BOARD_LIST_COUNT_URL } from "@/secret";
 
 const urlMatching: { [key: string]: string } = {
     'other': GET_OTHER_SCRAP_URL,
@@ -7,6 +7,8 @@ const urlMatching: { [key: string]: string } = {
     'product': GET_PRODUCT_SCRAP_URL,
     'video': GET_VIDEO_SCRAP_URL,
 }
+
+const token = localStorage.getItem("token");
 
 interface fetchGetScrapCountProps {
     type: string,
@@ -32,5 +34,27 @@ const fetchGetScrapCount = async({type, token}: fetchGetScrapCountProps) => {
 
 export const useGetScrapCount = async({type, token}: fetchGetScrapCountProps) => {
     const count = await fetchGetScrapCount({type: type, token: token});
+    return count;
+}
+
+const getBoardListCount = async() => {
+    const response = token && await fetch(GET_BOARD_LIST_COUNT_URL, {
+        method: "GET",
+        headers: {
+            "Content-Type": "application/json",
+            "X-AUTH-TOKEN": token,
+        },
+    })
+
+    const body = response && await response.json();
+    if (response && response.ok) {
+        return body;
+    } else {
+        throw new Error(body.resultCode);
+    }
+}
+
+export const useGetBoardListCount = async() => {
+    const count = await getBoardListCount();
     return count;
 }

--- a/src/components/molcules/BoardListHeader.tsx
+++ b/src/components/molcules/BoardListHeader.tsx
@@ -3,13 +3,37 @@ import { Box, Button, Typography } from '@mui/material';
 import theme from '../../assets/styles/theme';
 import SearchBar from '@/components/molcules/SearchBar';
 import { useModal } from '@/hooks/useModal';
+import { useQuery } from '@tanstack/react-query';
+import { useGetBoardListCount } from '@/api/count';
 
-interface ScrapListHeaderProps {
-    count: number,
-}
-
-function BoardListHeader({ count }: ScrapListHeaderProps) {
+function BoardListHeader() {
     const { openModal } = useModal();
+    const { data, isLoading } = useQuery(['boardCount'],
+        () => {
+            return useGetBoardListCount();
+        },
+        {
+            refetchOnWindowFocus: false,
+            select: (data) => {
+                return data?.data.count;
+            }
+        }
+    );
+
+    if (isLoading) {
+        return (
+            <Box
+                sx={{
+                    position: 'absolute',
+                    top: '50%',
+                    left: '50%',
+                    transform: 'translate(-50%, -50%)',
+                }}
+            >
+                로딩중
+            </Box>
+        )
+    }
 
     return (
         <Box
@@ -49,7 +73,7 @@ function BoardListHeader({ count }: ScrapListHeaderProps) {
                             lineHeight: '150%',
                         }}
                     >
-                        {count} 개
+                        {data} 개
                     </Typography>
                 </Box>
                 <Button

--- a/src/components/molcules/BoardListHeader.tsx
+++ b/src/components/molcules/BoardListHeader.tsx
@@ -8,7 +8,7 @@ import { useGetBoardListCount } from '@/api/count';
 
 function BoardListHeader() {
     const { openModal } = useModal();
-    const { data, isLoading } = useQuery(['boardCount'],
+    const { data, isLoading } = useQuery(['boardListCount'],
         () => {
             return useGetBoardListCount();
         },

--- a/src/components/templates/BoardListTemplate.tsx
+++ b/src/components/templates/BoardListTemplate.tsx
@@ -50,7 +50,7 @@ function BoardListTemplate() {
     return (
         <>
             <ScrapListContainer>
-                <BoardListHeader count={1} />
+                <BoardListHeader />
                 <Box
                     sx={{
                         height: 'calc(100% - 145px)',


### PR DESCRIPTION
## 개요
- DAD-924

## 작업 사항
- 보드 api 구현
- 보드 리스트 헤더에서 count get 연결
- get한 데이터 연결 (loading 상태일 때는 로딩중 렌더링)
- 보드 생성 시 invalidate queries 적용

## 추후 작업 사항
- 보드 삭제 시에도 invalidate queries 필요

![image](https://github.com/SWM-team-forever/dadamda-frontend/assets/83866983/b85c6449-4429-4922-b113-50d1a1b48eed)
