### PR TITLE
[DAD-923] 보드 정보 수정 구현

### DIFF
--- a/src/api/board.ts
+++ b/src/api/board.ts
@@ -153,7 +153,7 @@ interface editBoardProps {
 
 const editBoard = async ({boardId, description, tag, name}: editBoardProps) => {
     const response = token && await fetch(`${EDIT_BOARD_URL}/${boardId}`, {
-        method: "PUT",
+        method: "PATCH",
         headers: {
             "Content-Type": "application/json",
             "X-AUTH-TOKEN": token,

--- a/src/api/board.ts
+++ b/src/api/board.ts
@@ -1,5 +1,5 @@
 import { useDefaultSnackbar } from "@/hooks/useWarningSnackbar";
-import { GET_BOARD_LIST_URL, POST_CREATE_BOARD_URL } from "@/secret";
+import { DELETE_BOARD_URL, EDIT_BOARD_URL, GET_BOARD_LIST_URL, GET_BOARD_URL, POST_CREATE_BOARD_URL } from "@/secret";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import * as Sentry from '@sentry/react';
 
@@ -78,6 +78,115 @@ export const usePostCreateBoard = () => {
         onError: (error) => {
             Sentry.captureException(error);
             useDefaultSnackbar('보드 생성에 실패하였습니다.', 'error');
+        },
+        useErrorBoundary: false,
+    });
+}
+
+const getBoard = async (boardId: string) => {
+    const response = token && await fetch(`${GET_BOARD_URL}/${boardId}`, {
+        method: "GET",
+        headers: {
+            "Content-Type": "application/json",
+            "X-AUTH-TOKEN": token,
+        },
+    }).then((response) => {
+        return response.json().then(body => {
+            if (response.ok) {
+                return body;
+            } else {
+                throw new Error(body.resultCode);
+            }
+        })
+    });
+
+    return response;
+}
+
+export const useGetBoard = async (boardId: string) => {
+    const board = await getBoard(boardId);
+    return board;
+}
+
+const deleteBoard = async (boardId: string) => {
+    const response = token && await fetch(`${DELETE_BOARD_URL}/${boardId}`, {
+        method: "DELETE",
+        headers: {
+            "Content-Type": "application/json",
+            "X-AUTH-TOKEN": token,
+        },
+    }).then((response) => {
+        return response.json().then(body => {
+            if (response.ok) {
+                return body;
+            } else {
+                throw new Error(body.resultCode);
+            }
+        })
+    });
+
+    return response;
+}
+
+export const useDeleteBoard = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation(deleteBoard, {
+        onSuccess: () => {
+            queryClient.invalidateQueries(['boards']);
+            useDefaultSnackbar('보드가 삭제되었습니다', 'success');
+        },
+        onError: (error) => {
+            Sentry.captureException(error);
+            useDefaultSnackbar('보드 삭제에 실패하였습니다.', 'error');
+        },
+        useErrorBoundary: false,
+    });
+}
+
+interface editBoardProps {
+    boardId: string,
+    name: string,
+    description: string,
+    tag: string,
+}
+
+const editBoard = async ({boardId, description, tag, name}: editBoardProps) => {
+    const response = token && await fetch(`${EDIT_BOARD_URL}/${boardId}`, {
+        method: "PUT",
+        headers: {
+            "Content-Type": "application/json",
+            "X-AUTH-TOKEN": token,
+        },
+        body: JSON.stringify({
+            name: name,
+            description: description,
+            tag: tag,
+        }),
+    }).then((response) => {
+        return response.json().then(body => {
+            if (response.ok) {
+                return body;
+            } else {
+                throw new Error(body.resultCode);
+            }
+        })
+    });
+
+    return response;
+}
+
+export const useEditBoard = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation(editBoard, {
+        onSuccess: () => {
+            queryClient.invalidateQueries(['boards']);
+            useDefaultSnackbar('보드가 수정되었습니다', 'success');
+        },
+        onError: (error) => {
+            Sentry.captureException(error);
+            useDefaultSnackbar('보드 수정에 실패하였습니다.', 'error');
         },
         useErrorBoundary: false,
     });

--- a/src/components/atoms/Board/DeleteBoardButton.tsx
+++ b/src/components/atoms/Board/DeleteBoardButton.tsx
@@ -1,0 +1,27 @@
+import { useDeleteBoard } from "@/api/board";
+import { useBoardAtom } from "@/hooks/useBoardAtom";
+import { useModal } from "@/hooks/useModal";
+import { Button } from "@mui/material";
+
+function DeleteBoardButton() {
+    const { board } = useBoardAtom();
+    const { mutate } = useDeleteBoard();
+    const { closeModal } = useModal();
+
+    const handleDeleteBoardButtonClick = () => {
+        (board.boardId) && mutate(board.boardId);
+        closeModal();
+    }
+
+    return (
+        <Button
+            variant="contained"
+            fullWidth
+            onClick={handleDeleteBoardButtonClick}
+        >
+            삭제하기
+        </Button>
+    );
+}
+
+export default DeleteBoardButton;

--- a/src/components/atoms/Modal/BoardEditModalElement.tsx
+++ b/src/components/atoms/Modal/BoardEditModalElement.tsx
@@ -1,0 +1,226 @@
+import { useDeleteBoard, useEditBoard } from "@/api/board";
+import theme from "@/assets/styles/theme";
+import DeleteBoardButton from "@/components/atoms/Board/DeleteBoardButton";
+import { useBoardAtom } from "@/hooks/useBoardAtom";
+import { useModal } from "@/hooks/useModal";
+import { MAX_BOARD_DESCRIPTION_LENGTH, MAX_BOARD_TITLE_LENGTH, useIsBlank, useIsLessThanLengthLimitation } from "@/hooks/useValidation";
+import { Typography, TextareaAutosize, Box, Chip, Button, FormHelperText } from "@mui/material";
+import { useState } from "react";
+
+function BoardEditModalElement() {
+    const { board } = useBoardAtom();
+
+    const [title, setTitle] = useState<string>(board.title || "");
+    const handleTitleValue = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setTitle(e.target.value);
+    }
+
+    const [description, setDescription] = useState<string>(board.description || "");
+    const handleDescriptionValue = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setDescription(e.target.value);
+    }
+
+    const [selectedTag, setSelectedTag] = useState<string>(board.tag || "");
+    const handleTagValue = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+        setSelectedTag(e.currentTarget.getAttribute('data-tagValue') || "");
+    }
+
+    const chipInformation = [
+        {
+            label: '엔터테인먼트/예술',
+            tagValue: "ENTERTAINMENT_ART",
+        },
+        {
+            label: '취미/여가/여행',
+            tagValue: "HOBBY_TRAVEL",
+        },
+        {
+            label: '생활/노하우/쇼핑',
+            tagValue: "LIFE_SHOPPING",
+        },
+        {
+            label: '지식/동향',
+            tagValue: "KNOWLEDGE_TREND",
+        }
+    ];
+
+    const { mutate } = useEditBoard();
+    const { closeModal } = useModal();
+    const handleEditBoardButtonClick = () => {
+        (title && description && selectedTag && board.boardId) && mutate({
+            name: title,
+            description: description,
+            tag: selectedTag,
+            boardId: board.boardId,
+        });
+        closeModal();
+    }
+
+    const validateTitle = () => {
+        if (useIsBlank(title)) {
+            return '공백만 입력되었습니다.';
+        }
+
+        if (!useIsLessThanLengthLimitation(title, MAX_BOARD_TITLE_LENGTH)) {
+            return `최대 ${MAX_BOARD_TITLE_LENGTH}글자까지만 입력 가능합니다.`;
+        }
+
+        return 'success';
+    }
+
+    const validateDescription = () => {
+        if (useIsBlank(description)) {
+            return '공백만 입력되었습니다.';
+        }
+
+        if (!useIsLessThanLengthLimitation(description, MAX_BOARD_DESCRIPTION_LENGTH)) {
+            return `최대 ${MAX_BOARD_DESCRIPTION_LENGTH}글자까지만 입력 가능합니다.`;
+        }
+
+        return 'success';
+    }
+
+    const validateTag = () => {
+        if (useIsBlank(selectedTag)) {
+            return '태그는 꼭 선택해주셔야 합니다';
+        }
+
+        return 'success';
+    }
+
+    const isValidationSuccess = () => [validateTitle(), validateDescription(), validateTag()].every(element => element === 'success');
+
+    return (
+        <Box
+            sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '10px',
+            }}
+        >
+            <Typography
+                color={theme.color.Gray_090}
+                variant="h3"
+                sx={{
+                    fontWeight: '600',
+                    lineHeight: '150%',
+                }}
+            >
+                제목
+            </Typography>
+            <TextareaAutosize
+                style={{
+                    resize: 'none',
+                    background: '#FFF',
+                    border: `1px solid ${theme.color.Gray_040}`,
+                    width: '100%',
+                    boxSizing: 'border-box',
+                    borderRadius: '8px',
+                    padding: '10px',
+                    fontSize: '14px',
+                    fontWeight: '500',
+                    lineHeight: '150%',
+                    color: theme.color.Gray_090,
+                }}
+                value={title}
+                onChange={e => handleTitleValue(e)}
+            />
+            <FormHelperText
+                sx={{
+                    alignSelf: 'start',
+                    color: '#f44336',
+                }}
+            >
+                {validateTitle() === 'success' ? ' ' : validateTitle()}
+            </FormHelperText>
+            <Typography
+                color={theme.color.Gray_090}
+                variant="h3"
+                sx={{
+                    fontWeight: '600',
+                    lineHeight: '150%',
+                }}
+            >
+                설명
+            </Typography>
+            <TextareaAutosize
+                style={{
+                    resize: 'none',
+                    background: '#FFF',
+                    border: `1px solid ${theme.color.Gray_040}`,
+                    width: '100%',
+                    boxSizing: 'border-box',
+                    borderRadius: '8px',
+                    padding: '10px',
+                    fontSize: '14px',
+                    fontWeight: '500',
+                    lineHeight: '150%',
+                    color: theme.color.Gray_090,
+                }}
+                value={description}
+                onChange={e => handleDescriptionValue(e)}
+            />
+            <FormHelperText
+                sx={{
+                    alignSelf: 'start',
+                    color: '#f44336',
+                }}
+            >
+                {validateDescription() === 'success' ? ' ' : validateDescription()}
+            </FormHelperText>
+            <Typography
+                color={theme.color.Gray_090}
+                variant="h3"
+                sx={{
+                    fontWeight: '600',
+                    lineHeight: '150%',
+                }}
+            >
+                태그
+            </Typography>
+            <Box>
+                {chipInformation.map((element, index) => {
+                    const isSelected = selectedTag === element.tagValue;
+
+                    return (
+                        <Chip
+                            key={index}
+                            label={element.label}
+                            sx={{
+                                background: isSelected ? theme.color.Blue_060 : theme.color.Gray_040,
+                                color: theme.color.Gray_090,
+                                fontWeight: '500',
+                                fontSize: '14px',
+                                lineHeight: '150%',
+                                borderRadius: '8px',
+                                padding: '10px',
+                                m: '0 10px 10px 0',
+                            }}
+                            onClick={e => handleTagValue(e)}
+                            data-tagValue={element.tagValue}
+                        />
+                    )
+                })}
+            </Box>
+            <FormHelperText
+                sx={{
+                    alignSelf: 'start',
+                    color: '#f44336',
+                }}
+            >
+                {validateTag() === 'success' ? ' ' : validateTag()}
+            </FormHelperText>
+            <DeleteBoardButton />
+            <Button
+                variant="contained"
+                fullWidth
+                onClick={handleEditBoardButtonClick}
+                disabled={!isValidationSuccess()}
+            >
+                해당 보드 변경하기
+            </Button>
+        </Box>
+    );
+}
+
+export default BoardEditModalElement;

--- a/src/components/atoms/Modal/BoardEditModalElement.tsx
+++ b/src/components/atoms/Modal/BoardEditModalElement.tsx
@@ -1,4 +1,4 @@
-import { useDeleteBoard, useEditBoard } from "@/api/board";
+import { useEditBoard } from "@/api/board";
 import theme from "@/assets/styles/theme";
 import DeleteBoardButton from "@/components/atoms/Board/DeleteBoardButton";
 import { useBoardAtom } from "@/hooks/useBoardAtom";
@@ -6,6 +6,25 @@ import { useModal } from "@/hooks/useModal";
 import { MAX_BOARD_DESCRIPTION_LENGTH, MAX_BOARD_TITLE_LENGTH, useIsBlank, useIsLessThanLengthLimitation } from "@/hooks/useValidation";
 import { Typography, TextareaAutosize, Box, Chip, Button, FormHelperText } from "@mui/material";
 import { useState } from "react";
+
+export const chipInformation = [
+    {
+        label: '엔터테인먼트/예술',
+        tagValue: "ENTERTAINMENT_ART",
+    },
+    {
+        label: '취미/여가/여행',
+        tagValue: "HOBBY_TRAVEL",
+    },
+    {
+        label: '생활/노하우/쇼핑',
+        tagValue: "LIFE_SHOPPING",
+    },
+    {
+        label: '지식/동향',
+        tagValue: "KNOWLEDGE_TREND",
+    }
+];
 
 function BoardEditModalElement() {
     const { board } = useBoardAtom();
@@ -24,25 +43,6 @@ function BoardEditModalElement() {
     const handleTagValue = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
         setSelectedTag(e.currentTarget.getAttribute('data-tagValue') || "");
     }
-
-    const chipInformation = [
-        {
-            label: '엔터테인먼트/예술',
-            tagValue: "ENTERTAINMENT_ART",
-        },
-        {
-            label: '취미/여가/여행',
-            tagValue: "HOBBY_TRAVEL",
-        },
-        {
-            label: '생활/노하우/쇼핑',
-            tagValue: "LIFE_SHOPPING",
-        },
-        {
-            label: '지식/동향',
-            tagValue: "KNOWLEDGE_TREND",
-        }
-    ];
 
     const { mutate } = useEditBoard();
     const { closeModal } = useModal();

--- a/src/components/templates/BoardListTemplate.tsx
+++ b/src/components/templates/BoardListTemplate.tsx
@@ -1,11 +1,13 @@
 import styled from 'styled-components';
 
-import { Box, Grid } from '@mui/material';
+import { Box, Chip, Grid, Typography } from '@mui/material';
 import BoardListHeader from '@/components/molcules/BoardListHeader';
 import theme from '@/assets/styles/theme';
 import { useNavigate } from 'react-router-dom';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useGetBoardList } from '@/api/board';
+import { MenuIcon } from '@/components/atoms/Icon';
+import { getTimeDiff } from '@/hooks/useCalculateDateDiff';
 
 export interface IBoardListInfo {
     boardId: number;
@@ -54,6 +56,7 @@ function BoardListTemplate() {
                 <Box
                     sx={{
                         height: 'calc(100% - 145px)',
+                        width: '100%',
                     }}
                 >
                     <Grid container
@@ -82,7 +85,7 @@ function BoardListTemplate() {
                             return page.data.content.map((board: IBoardListInfo) => {
                                 return (
                                     <Grid item
-                                        xs={13} sm={6} md={4} lg={3} xl={3}
+                                        xs={'auto'} sm={'auto'} md={'auto'} lg={'auto'} xl={'auto'}
                                         key={board.boardId}
                                         sx={{
 
@@ -94,14 +97,49 @@ function BoardListTemplate() {
                                                 height: '180px',
                                                 width: '100%',
                                                 backgroundColor: theme.color.Blue_090,
-                                                borderRadius: '8px',
+                                                borderRadius: '8px 8px 0 0',
                                                 cursor: 'pointer',
                                                 '&:hover': {
                                                     backgroundColor: theme.color.Blue_080,
                                                 },
                                             }}
                                         >
-                                            {board.boardName}
+                                        </Box>
+                                        <Box
+                                            sx={{
+                                                p: '10px',
+                                                backgroundColor: theme.color.Gray_020,
+                                                borderRadius: '0 0 8px 8px',
+                                            }}
+                                        >
+                                            <Box
+                                                sx={{
+                                                    display: 'flex',
+                                                    justifyContent: 'space-between',
+                                                    alignItems: 'center',
+                                                }}
+                                            >
+                                                <Typography>{board.boardName}</Typography>
+                                                <Box
+                                                    sx={{
+                                                        display: 'flex',
+                                                        gap: '5px',
+                                                    }}
+                                                >
+                                                    <MenuIcon width='12' height='12' fill={theme.color.Gray_070} />
+                                                    <MenuIcon width='12' height='12' fill={theme.color.Gray_070} />
+                                                </Box>
+                                            </Box>
+                                            <Box
+                                                sx={{
+                                                    display: 'flex',
+                                                    alignItems: 'center',
+                                                    gap: '10px',
+                                                }}
+                                            >
+                                                <Chip label={board.tag} />
+                                                <Typography>{getTimeDiff(board.modifiedDate)}</Typography>
+                                            </Box>
                                         </Box>
                                     </Grid>
                                 )

--- a/src/components/templates/BoardListTemplate.tsx
+++ b/src/components/templates/BoardListTemplate.tsx
@@ -133,7 +133,14 @@ function BoardListTemplate() {
                                                         }}
                                                         onClick={async (e) => {
                                                             e.stopPropagation();
-                                                            const boardInfo = await useGetBoard(board.boardId.toString());
+                                                            let boardInfo = await useGetBoard(board.boardId.toString());
+                                                            boardInfo = {
+                                                                ...boardInfo,
+                                                                data: {
+                                                                    ...boardInfo.data,
+                                                                    title: boardInfo.data.name,
+                                                                }
+                                                            }
                                                             setBoard((prev) => ({
                                                                 ...prev,
                                                                 boardId: board.boardId.toString(),

--- a/src/components/templates/BoardListTemplate.tsx
+++ b/src/components/templates/BoardListTemplate.tsx
@@ -10,6 +10,7 @@ import { MenuIcon } from '@/components/atoms/Icon';
 import { getTimeDiff } from '@/hooks/useCalculateDateDiff';
 import { useModal } from '@/hooks/useModal';
 import { useBoardAtom } from '@/hooks/useBoardAtom';
+import { chipInformation } from '@/components/atoms/Modal/BoardEditModalElement';
 
 export interface IBoardListInfo {
     boardId: number;
@@ -160,7 +161,9 @@ function BoardListTemplate() {
                                                     gap: '10px',
                                                 }}
                                             >
-                                                <Chip label={board.tag} />
+                                                <Chip label={chipInformation.map((chipInfo) =>
+                                                    chipInfo.tagValue === board.tag && chipInfo.label
+                                                )} />
                                                 <Typography>{getTimeDiff(board.modifiedDate)}</Typography>
                                             </Box>
                                         </Box>

--- a/src/components/templates/BoardListTemplate.tsx
+++ b/src/components/templates/BoardListTemplate.tsx
@@ -70,7 +70,6 @@ function BoardListTemplate() {
                     <Box
                         sx={{
                             width: '100%',
-                            height: '100%',
                             m: '0',
                             display: 'grid',
                             gap: 2,
@@ -84,12 +83,12 @@ function BoardListTemplate() {
                                 xl: 'repeat(5, 1fr)',
                             }
                         }
+                        gridAutoRows={'auto'}
                     >
                         {data?.pages.map((page) => {
                             return page.data.content.map((board: IBoardListInfo) => {
                                 return (
                                     <Grid item
-                                        xs={12} sm={6} md={4} lg={3} xl={3}
                                         key={board.boardId}
                                         onClick={() => navigate(`/board_info?boardId=${board.boardId}`)}
                                     >

--- a/src/components/templates/BoardListTemplate.tsx
+++ b/src/components/templates/BoardListTemplate.tsx
@@ -91,7 +91,7 @@ function BoardListTemplate() {
                                     <Grid item
                                         xs={12} sm={6} md={4} lg={3} xl={3}
                                         key={board.boardId}
-                                        onClick={() => navigate(`/board_info?boardId=${board.boardId}&title=${board.boardName}`)}
+                                        onClick={() => navigate(`/board_info?boardId=${board.boardId}`)}
                                     >
                                         <Box
                                             sx={{

--- a/src/components/templates/BoardListTemplate.tsx
+++ b/src/components/templates/BoardListTemplate.tsx
@@ -5,10 +5,11 @@ import BoardListHeader from '@/components/molcules/BoardListHeader';
 import theme from '@/assets/styles/theme';
 import { useNavigate } from 'react-router-dom';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { useGetBoardList } from '@/api/board';
+import { useGetBoard, useGetBoardList } from '@/api/board';
 import { MenuIcon } from '@/components/atoms/Icon';
 import { getTimeDiff } from '@/hooks/useCalculateDateDiff';
 import { useModal } from '@/hooks/useModal';
+import { useBoardAtom } from '@/hooks/useBoardAtom';
 
 export interface IBoardListInfo {
     boardId: number;
@@ -35,6 +36,8 @@ function BoardListTemplate() {
             },
         }
     );
+
+    const { setBoard } = useBoardAtom();
 
     if (isLoading) {
         return (
@@ -128,9 +131,15 @@ function BoardListTemplate() {
                                                         sx={{
                                                             cursor: 'pointer',
                                                         }}
-                                                        onClick={(e) => {
+                                                        onClick={async (e) => {
                                                             e.stopPropagation();
-                                                            openModal('boardCreate')
+                                                            const boardInfo = await useGetBoard(board.boardId.toString());
+                                                            setBoard((prev) => ({
+                                                                ...prev,
+                                                                boardId: board.boardId.toString(),
+                                                                ...boardInfo.data,
+                                                            }))
+                                                            openModal('boardEdit');
                                                         }}
                                                     >
                                                         <MenuIcon width='12' height='12' fill={theme.color.Gray_070} />

--- a/src/components/templates/BoardListTemplate.tsx
+++ b/src/components/templates/BoardListTemplate.tsx
@@ -75,7 +75,7 @@ function BoardListTemplate() {
                                 sm: 'repeat(2, 1fr)',
                                 md: 'repeat(3, 1fr)',
                                 lg: 'repeat(4, 1fr)',
-                                xl: 'repeat(6, 1fr)',
+                                xl: 'repeat(4, 1fr)',
                             }
                         }
                     >
@@ -83,7 +83,7 @@ function BoardListTemplate() {
                             return page.data.content.map((board: IBoardListInfo) => {
                                 return (
                                     <Grid item
-                                        xs={12} sm={6} md={4} lg={3} xl={2}
+                                        xs={12} sm={6} md={4} lg={3} xl={3}
                                         key={board.boardId}
                                         onClick={() => navigate(`/board_info?boardId=${board.boardId}&title=${board.boardName}`)}
                                     >

--- a/src/components/templates/BoardListTemplate.tsx
+++ b/src/components/templates/BoardListTemplate.tsx
@@ -81,7 +81,7 @@ function BoardListTemplate() {
                                 sm: 'repeat(2, 1fr)',
                                 md: 'repeat(3, 1fr)',
                                 lg: 'repeat(4, 1fr)',
-                                xl: 'repeat(4, 1fr)',
+                                xl: 'repeat(5, 1fr)',
                             }
                         }
                     >

--- a/src/components/templates/BoardListTemplate.tsx
+++ b/src/components/templates/BoardListTemplate.tsx
@@ -57,32 +57,59 @@ function BoardListTemplate() {
                     }}
                 >
                     <Grid container
-                        // columns={{ xs: 1, sm: 2, md: 3, lg: 4, xl: 5 }}
                         sx={{
-                            gap: '16px',
-                            padding: '24px',
+                            width: '100%',
+                            height: '100%',
+                            p: '10px 24px',
+                        }}
+                        columns={13}
+                        rowGap={{
+                            xs: 1,
+                            sm: 4,
+                            md: 3.5,
+                            lg: 3.5,
+                            xl: 3.5,
+                        }}
+                        columnGap={{
+                            xs: 1,
+                            sm: 4,
+                            md: 3.5,
+                            lg: 3.5,
+                            xl: 3.5,
                         }}
                     >
                         {data?.pages.map((page) => {
                             return page.data.content.map((board: IBoardListInfo) => {
                                 return (
                                     <Grid item
-                                        xs={12} sm={6} md={4} lg={3} xl={2}
+                                        xs={13} sm={6} md={4} lg={3} xl={3}
                                         key={board.boardId}
                                         sx={{
-                                            height: '180px',
-                                            backgroundColor: theme.color.Blue_090,
+
                                         }}
                                         onClick={() => navigate(`/board_info?boardId=${board.boardId}&title=${board.boardName}`)}
                                     >
-                                        {board.boardName}
+                                        <Box
+                                            sx={{
+                                                height: '180px',
+                                                width: '100%',
+                                                backgroundColor: theme.color.Blue_090,
+                                                borderRadius: '8px',
+                                                cursor: 'pointer',
+                                                '&:hover': {
+                                                    backgroundColor: theme.color.Blue_080,
+                                                },
+                                            }}
+                                        >
+                                            {board.boardName}
+                                        </Box>
                                     </Grid>
                                 )
                             })
                         })}
                     </Grid>
                 </Box>
-            </ScrapListContainer>
+            </ScrapListContainer >
         </>
     );
 }

--- a/src/components/templates/BoardListTemplate.tsx
+++ b/src/components/templates/BoardListTemplate.tsx
@@ -83,7 +83,6 @@ function BoardListTemplate() {
                                 xl: 'repeat(5, 1fr)',
                             }
                         }
-                        gridAutoRows={'auto'}
                     >
                         {data?.pages.map((page) => {
                             return page.data.content.map((board: IBoardListInfo) => {

--- a/src/components/templates/BoardListTemplate.tsx
+++ b/src/components/templates/BoardListTemplate.tsx
@@ -57,39 +57,34 @@ function BoardListTemplate() {
                     sx={{
                         height: 'calc(100% - 145px)',
                         width: '100%',
+                        p: '10px 24px',
+                        boxSizing: 'border-box',
                     }}
                 >
-                    <Grid container
+                    <Box
                         sx={{
                             width: '100%',
                             height: '100%',
-                            p: '10px 24px',
+                            m: '0',
+                            display: 'grid',
+                            gap: 2,
                         }}
-                        columns={13}
-                        rowGap={{
-                            xs: 1,
-                            sm: 4,
-                            md: 3.5,
-                            lg: 3.5,
-                            xl: 3.5,
-                        }}
-                        columnGap={{
-                            xs: 1,
-                            sm: 4,
-                            md: 3.5,
-                            lg: 3.5,
-                            xl: 3.5,
-                        }}
+                        gridTemplateColumns={
+                            {
+                                xs: 'repeat(1, 1fr)',
+                                sm: 'repeat(2, 1fr)',
+                                md: 'repeat(3, 1fr)',
+                                lg: 'repeat(4, 1fr)',
+                                xl: 'repeat(6, 1fr)',
+                            }
+                        }
                     >
                         {data?.pages.map((page) => {
                             return page.data.content.map((board: IBoardListInfo) => {
                                 return (
                                     <Grid item
-                                        xs={'auto'} sm={'auto'} md={'auto'} lg={'auto'} xl={'auto'}
+                                        xs={12} sm={6} md={4} lg={3} xl={2}
                                         key={board.boardId}
-                                        sx={{
-
-                                        }}
                                         onClick={() => navigate(`/board_info?boardId=${board.boardId}&title=${board.boardName}`)}
                                     >
                                         <Box
@@ -145,7 +140,7 @@ function BoardListTemplate() {
                                 )
                             })
                         })}
-                    </Grid>
+                    </Box>
                 </Box>
             </ScrapListContainer >
         </>

--- a/src/components/templates/BoardListTemplate.tsx
+++ b/src/components/templates/BoardListTemplate.tsx
@@ -8,6 +8,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { useGetBoardList } from '@/api/board';
 import { MenuIcon } from '@/components/atoms/Icon';
 import { getTimeDiff } from '@/hooks/useCalculateDateDiff';
+import { useModal } from '@/hooks/useModal';
 
 export interface IBoardListInfo {
     boardId: number;
@@ -20,6 +21,7 @@ export interface IBoardListInfo {
 
 function BoardListTemplate() {
     const navigate = useNavigate();
+    const { openModal } = useModal();
 
     const { data, isLoading } = useInfiniteQuery(
         ['boards'],
@@ -122,7 +124,17 @@ function BoardListTemplate() {
                                                     }}
                                                 >
                                                     <MenuIcon width='12' height='12' fill={theme.color.Gray_070} />
-                                                    <MenuIcon width='12' height='12' fill={theme.color.Gray_070} />
+                                                    <Box
+                                                        sx={{
+                                                            cursor: 'pointer',
+                                                        }}
+                                                        onClick={(e) => {
+                                                            e.stopPropagation();
+                                                            openModal('boardCreate')
+                                                        }}
+                                                    >
+                                                        <MenuIcon width='12' height='12' fill={theme.color.Gray_070} />
+                                                    </Box>
                                                 </Box>
                                             </Box>
                                             <Box

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -12,6 +12,7 @@ import ScrapCreateModalElement from "@/components/atoms/Modal/ScrapCreateModalEl
 import ScrapPasteModalElement from "@/components/atoms/Modal/ScrapPasteModalElement";
 import BoardCreateModalElement from "@/components/atoms/Modal/BoardCreateModalElement";
 import StickerPasteModalElement from "@/components/atoms/Modal/StickerPasteModalElement";
+import BoardEditModalElement from "@/components/atoms/Modal/BoardEditModalElement";
 
 export const useModal = () => {
     const [modal, setModal] = useAtom(modalAtom);
@@ -65,6 +66,11 @@ export const useModal = () => {
             title: '스티커 추가하기',
             element: <StickerPasteModalElement />,
             position: 'center',
+        },
+        boardEdit: {
+            title: '보드 수정하기',
+            element: <BoardEditModalElement />,
+            position: 'right',
         }
     }
 

--- a/src/pages/BoardInfoPage.tsx
+++ b/src/pages/BoardInfoPage.tsx
@@ -1,3 +1,4 @@
+import { useGetBoard } from "@/api/board";
 import { TrashableItems } from "@/components/templates/TrashableItems";
 import { useBoardAtom } from "@/hooks/useBoardAtom";
 import { useModal } from "@/hooks/useModal";
@@ -105,7 +106,29 @@ function BoardInfoPage() {
                 <Button>
                     공유
                 </Button>
-                <Button>
+                <Button
+                    onClick={async () => {
+                        if (boardPageId === null) {
+                            return;
+                        }
+
+                        let boardInfo = await useGetBoard(boardPageId.toString());
+                        boardInfo = {
+                            ...boardInfo,
+                            data: {
+                                ...boardInfo.data,
+                                title: boardInfo.data.name,
+                            }
+                        }
+                        setBoard((prev) => ({
+                            ...prev,
+                            boardId: boardPageId.toString(),
+                            ...boardInfo.data,
+                        }))
+                        openModal('boardEdit');
+                    }
+                    }
+                >
                     설정
                 </Button>
             </Box>

--- a/src/pages/BoardInfoPage.tsx
+++ b/src/pages/BoardInfoPage.tsx
@@ -37,7 +37,7 @@ function BoardInfoPage() {
         }
 
         fetchBoardInfo();
-    }, [boardPageId, setBoard, board])
+    }, [boardPageId, board.title])
 
     const { openModal } = useModal();
 

--- a/src/pages/BoardInfoPage.tsx
+++ b/src/pages/BoardInfoPage.tsx
@@ -3,31 +3,41 @@ import { TrashableItems } from "@/components/templates/TrashableItems";
 import { useBoardAtom } from "@/hooks/useBoardAtom";
 import { useModal } from "@/hooks/useModal";
 import { Box, Button, Typography } from "@mui/material";
-import { useLayoutEffect } from "react";
 import { useSearchParams } from "react-router-dom";
+import { useLayoutEffect } from "react";
 
 function BoardInfoPage() {
     const [searchParams, setSearchParams] = useSearchParams();
 
-    function getBoardPageId() {
+    function getBoardPageId(): string | null {
         return searchParams.get('boardId');
-    }
-
-    function getTitle() {
-        return searchParams.get('title');
     }
 
     const { board, setBoard } = useBoardAtom();
     const boardPageId = getBoardPageId();
-    const boardTitle = getTitle();
 
     useLayoutEffect(() => {
-        (boardTitle && boardPageId) && setBoard({
-            ...board,
-            title: boardTitle,
-            boardId: boardPageId,
-        });
-    }, [])
+        async function fetchBoardInfo() {
+            if (boardPageId === null) {
+                return;
+            }
+            let boardInfo = await useGetBoard(boardPageId.toString());
+            boardInfo = {
+                ...boardInfo,
+                data: {
+                    ...boardInfo.data,
+                    title: boardInfo.data.name,
+                }
+            }
+            setBoard((prev) => ({
+                ...prev,
+                boardId: boardPageId,
+                ...boardInfo.data,
+            }))
+        }
+
+        fetchBoardInfo();
+    }, [boardPageId, setBoard, board])
 
     const { openModal } = useModal();
 
@@ -107,32 +117,12 @@ function BoardInfoPage() {
                     공유
                 </Button>
                 <Button
-                    onClick={async () => {
-                        if (boardPageId === null) {
-                            return;
-                        }
-
-                        let boardInfo = await useGetBoard(boardPageId.toString());
-                        boardInfo = {
-                            ...boardInfo,
-                            data: {
-                                ...boardInfo.data,
-                                title: boardInfo.data.name,
-                            }
-                        }
-                        setBoard((prev) => ({
-                            ...prev,
-                            boardId: boardPageId.toString(),
-                            ...boardInfo.data,
-                        }))
-                        openModal('boardEdit');
-                    }
-                    }
+                    onClick={() => openModal('boardEdit')}
                 >
                     설정
                 </Button>
             </Box>
-        </Box>
+        </Box >
     );
 }
 

--- a/src/state/boardAtom.ts
+++ b/src/state/boardAtom.ts
@@ -4,6 +4,8 @@ import { atom } from "jotai";
 const boardAtom = atom<IBoardAtom>({
     title: '',
     boardId: '',
+    description: '',
+    tag: '',
 });
 
 export default boardAtom;

--- a/src/types/IBoardAtom.ts
+++ b/src/types/IBoardAtom.ts
@@ -11,6 +11,8 @@ export type Column = {
 interface IBoardAtom {
     title: string,
     boardId: string | null,
+    description?: string,
+    tag?: string,
 }
 
 export type {IBoardAtom};


### PR DESCRIPTION
## 개요
- DAD-923

## 작업사항
- 보드 정보 수정 및 삭제 모달 생성
- 보드 목록 페이지에 모달 연결
- 보드 페이지 생성 버튼에 모달 연결

## 변경로직(Optional)
- 보드 info page에서 url을 통해 title을 가져오는 로직을 atom을 통해 가져오도록 변경 (board info page에서 타이틀 변경해도 렌더링에 반영되지 않는 문제가 있어서 atom을 사용하도록 변경함)

## 셀프 리뷰
- 반복되는 코드를 추상화할 방법 연구 필요