### PR TITLE
[DAD-975] 보드 편집/보기 모드 개발 (제이크)

### DIFF
--- a/src/components/atoms/Icon.tsx
+++ b/src/components/atoms/Icon.tsx
@@ -277,3 +277,13 @@ export function DownIcon({ width, height, fill }: IconProps) {
         </svg>
     )
 }
+
+export function TrashCanIcon({ width, height, fill }: IconProps) {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} viewBox="0 0 18 18" fill={fill}>
+            <path d="M14.8981 7L14.0137 16.0968C13.9638 16.6092 13.5332 17 13.0183 17H4.98165C4.46685 17 4.03616 16.6092 3.98634 16.0968L3.10194 7H14.8981Z" fill={fill} stroke={fill} stroke-width="2" stroke-linecap="round" />
+            <line x1="1" y1="5" x2="17" y2="5" stroke={fill} stroke-width="2" stroke-linecap="round" />
+            <line x1="6" y1="1" x2="12" y2="0.999999" stroke={fill} stroke-width="2" stroke-linecap="round" />
+        </svg>
+    )
+}

--- a/src/components/templates/BB.jsx
+++ b/src/components/templates/BB.jsx
@@ -691,7 +691,7 @@ export function MultipleContainers({
                             </SortableContext>
                         </DroppableContainer>
                     ))}
-                    {minimal ? undefined : (
+                    {minimal | isViewerMode(mode) ? undefined : (
                         <DroppableContainer
                             id={PLACEHOLDER_ID}
                             disabled={isSortingContainer}

--- a/src/components/templates/BB.jsx
+++ b/src/components/templates/BB.jsx
@@ -730,7 +730,7 @@ export function MultipleContainers({
             )}
             {trashable && activeId && !containers.includes(activeId) ? (
                 <Trash id={TRASH_ID} />
-            ) : <Trash id={TRASH_ID} />}
+            ) : null}
         </DndContext>
     );
 
@@ -817,7 +817,7 @@ function getColor(id) {
     return undefined;
 }
 
-function Trash({ id }) {
+function Trash({ id, mode }) {
     const { setNodeRef, isOver } = useDroppable({
         id,
     });
@@ -841,7 +841,7 @@ function Trash({ id }) {
                 backgroundColor: isOver ? theme.color.Blue_080 : 'none',
             }}
         >
-            <TrashCanIcon width='30' height='30' fill={isOver? 'white' : theme.color.Gray_060}/>
+            {!isViewerMode(mode) && <TrashCanIcon width='30' height='30' fill={isOver? 'white' : theme.color.Gray_060}/>}
         </Box>
     );
 }

--- a/src/components/templates/BB.jsx
+++ b/src/components/templates/BB.jsx
@@ -288,7 +288,11 @@ export const Item = React.memo(
                     >
                         {
                             value.scrapId
-                            ? <ScrapCard content={value} key={value.id}/>
+                            ? <Box
+                                onClick={() => !isViewerMode(mode) && window.open(value.pageUrl)}
+                            >
+                                <ScrapCard content={value} key={value.id}/>
+                            </Box>
                             : <Sticker content={value} key={value.id}/>
                         }
                     </div>

--- a/src/components/templates/BB.jsx
+++ b/src/components/templates/BB.jsx
@@ -663,7 +663,7 @@ export function MultipleContainers({
                             style={containerStyle}
                             unstyled={minimal}
                             onRemove={() => {
-                                handleRemove(containerId)
+                                !isViewerMode && handleRemove(containerId)
                             }}
                         >
                             <SortableContext 

--- a/src/components/templates/BB.jsx
+++ b/src/components/templates/BB.jsx
@@ -110,6 +110,7 @@ export const Container = forwardRef(
             scrollable,
             shadow,
             unstyled,
+            mode,
             ...props
         },
         ref
@@ -140,8 +141,8 @@ export const Container = forwardRef(
                     gap: '5px',
                 }}
                 >
-                    {onRemove ? <Remove onClick={onRemove} /> : undefined}
-                    <Handle {...handleProps} />
+                    {onRemove && !isViewerMode(mode) ? <Remove onClick={onRemove} /> : undefined}
+                    {!isViewerMode(mode) && <Handle {...handleProps} />}
                 </Box>) : null}
                 {placeholder ? children : <ul
                 style={{
@@ -240,6 +241,7 @@ export const Item = React.memo(
                 transform,
                 value,
                 itemId,
+                mode,
                 wrapperStyle,
                 ...props
             },
@@ -299,9 +301,7 @@ export const TRASH_ID = 'void';
 const PLACEHOLDER_ID = 'placeholder';
 const empty = [];
 
-function isViewerMode(mode) {
-    return mode === 'view';
-}
+const isViewerMode = (mode) => mode === 'view';
 
 export function MultipleContainers({
     adjustScale = false,
@@ -665,6 +665,7 @@ export function MultipleContainers({
                             onRemove={() => {
                                 !isViewerMode && handleRemove(containerId)
                             }}
+                            mode={mode}
                         >
                             <SortableContext 
                             items={boardContent[containerId]} 

--- a/src/components/templates/BB.jsx
+++ b/src/components/templates/BB.jsx
@@ -832,7 +832,7 @@ function Trash({ id }) {
                 position: 'fixed',
                 right: {
                     xs: '10px',
-                    sm: '100px',
+                    sm: '110px',
                 },
                 top: '60px',
                 width: isOver ? '120px' : '60px',

--- a/src/components/templates/BB.jsx
+++ b/src/components/templates/BB.jsx
@@ -664,7 +664,7 @@ export function MultipleContainers({
                             style={containerStyle}
                             unstyled={minimal}
                             onRemove={() => {
-                                !isViewerMode && handleRemove(containerId)
+                                !isViewerMode(mode) && handleRemove(containerId)
                             }}
                             mode={mode}
                         >

--- a/src/components/templates/BB.jsx
+++ b/src/components/templates/BB.jsx
@@ -729,7 +729,7 @@ export function MultipleContainers({
             )}
             {trashable && activeId && !containers.includes(activeId) ? (
                 <Trash id={TRASH_ID} />
-            ) : null}
+            ) : <Trash id={TRASH_ID} />}
         </DndContext>
     );
 
@@ -822,25 +822,27 @@ function Trash({ id }) {
     });
 
     return (
-        <div
+        <Box
             ref={setNodeRef}
-            style={{
+            sx={{
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
                 position: 'fixed',
-                left: '50%',
-                marginLeft: -150,
-                bottom: 20,
-                width: 300,
+                right: {
+                    xs: '10px',
+                    sm: '100px',
+                },
+                top: '60px',
+                width: 280,
                 height: 60,
                 borderRadius: 5,
                 border: '1px solid',
                 borderColor: isOver ? 'red' : '#DDD',
             }}
         >
-            제거하고 싶은 요소를 드래그 해주세요
-        </div>
+            제거하고 싶은 요소를 이곳에 놓아주세요.
+        </Box>
     );
 }
 

--- a/src/components/templates/BB.jsx
+++ b/src/components/templates/BB.jsx
@@ -34,6 +34,7 @@ import { useGetBoardContents } from '@/api/board';
 import { useBoardAtom } from '@/hooks/useBoardAtom';
 import { useDefaultSnackbar } from '@/hooks/useWarningSnackbar';
 import * as Sentry from '@sentry/react';
+import { TrashCanIcon } from '../atoms/Icon';
 
 const animateLayoutChanges = (args) =>
     defaultAnimateLayoutChanges({ ...args, wasDragging: true });
@@ -834,14 +835,13 @@ function Trash({ id }) {
                     sm: '100px',
                 },
                 top: '60px',
-                width: 280,
-                height: 60,
-                borderRadius: 5,
-                border: '1px solid',
-                borderColor: isOver ? 'red' : '#DDD',
+                width: isOver ? '120px' : '60px',
+                height: isOver ? '120px' : '60px',
+                borderRadius: '50%',
+                backgroundColor: isOver ? theme.color.Blue_080 : 'none',
             }}
         >
-            제거하고 싶은 요소를 이곳에 놓아주세요.
+            <TrashCanIcon width='30' height='30' fill={isOver? 'white' : theme.color.Gray_060}/>
         </Box>
     );
 }

--- a/src/components/templates/BB.jsx
+++ b/src/components/templates/BB.jsx
@@ -299,6 +299,10 @@ export const TRASH_ID = 'void';
 const PLACEHOLDER_ID = 'placeholder';
 const empty = [];
 
+function isViewerMode(mode) {
+    return mode === 'view';
+}
+
 export function MultipleContainers({
     adjustScale = false,
     itemCount = 3,
@@ -316,6 +320,7 @@ export function MultipleContainers({
     trashable = false,
     vertical = false,
     scrollable,
+    mode,
 }) {
 
     const {
@@ -645,6 +650,7 @@ export function MultipleContainers({
                             ? verticalListSortingStrategy
                             : horizontalListSortingStrategy
                     }
+                    disabled={isViewerMode(mode)}
                 >
                     {containers.map((containerId) => (
                         <DroppableContainer
@@ -660,7 +666,11 @@ export function MultipleContainers({
                                 handleRemove(containerId)
                             }}
                         >
-                            <SortableContext items={boardContent[containerId]} strategy={strategy}>
+                            <SortableContext 
+                            items={boardContent[containerId]} 
+                            strategy={strategy}
+                            disabled={isViewerMode(mode)}
+                            >
                                 {boardContent[containerId].map((value, index) => {
                                     return (
                                         <SortableItem

--- a/src/components/templates/TrashableItems.tsx
+++ b/src/components/templates/TrashableItems.tsx
@@ -2,7 +2,7 @@ import { TRASH_ID, MultipleContainers } from "@/components/templates/BB.jsx";
 import { UniqueIdentifier, CancelDrop } from "@dnd-kit/core";
 import { useState, useRef } from "react";
 
-export const TrashableItems = ({ confirmDrop }: { confirmDrop: boolean }) => {
+export const TrashableItems = ({ confirmDrop, mode }: { confirmDrop: boolean, mode: string }) => {
     const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
     const resolveRef = useRef<(value: boolean) => void>();
 
@@ -33,6 +33,7 @@ export const TrashableItems = ({ confirmDrop }: { confirmDrop: boolean }) => {
                 modifiers={undefined}
                 renderItem={undefined}
                 scrollable={undefined}
+                mode={mode}
             />
         </>
     );

--- a/src/hooks/useBoardContentAtom.ts
+++ b/src/hooks/useBoardContentAtom.ts
@@ -45,10 +45,10 @@ export const useBoardContentAtom = () => {
         setContainers(Object.keys(newBoard));
     }
 
-    function handleAddColumn() {
+    function handleAddColumn(mode: 'view' | 'edit') {
         const newContainerId = getNextContainerId();
 
-        unstable_batchedUpdates(() => {
+        mode === 'edit' && unstable_batchedUpdates(() => {
             setContainers((containers) => [...containers, newContainerId]);
             setBoardContent((items) => ({
                 ...items,

--- a/src/pages/BoardInfoPage.tsx
+++ b/src/pages/BoardInfoPage.tsx
@@ -4,9 +4,11 @@ import { useBoardAtom } from "@/hooks/useBoardAtom";
 import { useModal } from "@/hooks/useModal";
 import { Box, Button, Typography } from "@mui/material";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useDefaultSnackbar } from "@/hooks/useWarningSnackbar";
 import { useBoardContentAtom } from "@/hooks/useBoardContentAtom";
+import { useState } from "react";
+
 
 function BoardInfoPage() {
     const [searchParams, setSearchParams] = useSearchParams();
@@ -17,6 +19,7 @@ function BoardInfoPage() {
 
     const { board, setBoard } = useBoardAtom();
     const boardPageId = getBoardPageId();
+    const [mode, setMode] = useState<'view' | 'edit'>('view');
 
     const navigate = useNavigate();
 
@@ -109,7 +112,7 @@ function BoardInfoPage() {
                         justifyContent: 'space-between',
                     }}
                 >
-                    {boardPageId && <TrashableItems confirmDrop={false} />}
+                    {boardPageId && <TrashableItems confirmDrop={false} mode={mode} />}
                 </Box>
             </Box>
             <Box
@@ -137,9 +140,21 @@ function BoardInfoPage() {
                 >
                     스티커 추가
                 </Button>
-                <Button>
-                    편집 모드
-                </Button>
+                {mode === 'view' ? (
+                    <Button
+                        onClick={() => setMode('edit')}
+                    >
+                        편집 모드
+                    </Button>
+                )
+                    : (
+                        <Button
+                            onClick={() => setMode('view')}
+                        >
+                            보기 모드
+                        </Button>
+                    )
+                }
                 <Button
                     onClick={handleSaveBoard}
                 >


### PR DESCRIPTION
## 개요
- DAD-975

## 작업사항
- 보드 편집 모드, 보기 모드 개발
- mode에 따라 우측 버튼 패널에 '보기 모드' / '편집 모드' 버튼 글씨 변경
- mode에 따라 열 추가 버튼 보이기, handle/remove 버튼 보이기 제어
- mode에 따라 열과 items DND 가능 여부 제어
- 쓰레기통 위치 변경 및 스타일링 변경

## 변경로직(Optional)
- trashableItems와 MultipleContainers에 mode props 전달

## ui (보기 모드)
![image](https://github.com/SWM-team-forever/dadamda-frontend/assets/83866983/4419a73a-81b5-42b1-a372-154949c259f8)

## ui(쓰레기통)
![image](https://github.com/SWM-team-forever/dadamda-frontend/assets/83866983/71dd07b0-6895-45da-a2b6-55840c1f2d7f)
