### PR TITLE
[DAD-948] amplitude 연결 추가

### DIFF
--- a/src/components/atoms/Board/DeleteBoardButton.tsx
+++ b/src/components/atoms/Board/DeleteBoardButton.tsx
@@ -1,6 +1,7 @@
 import { useDeleteBoard } from "@/api/board";
 import { useBoardAtom } from "@/hooks/useBoardAtom";
 import { useModal } from "@/hooks/useModal";
+import { logEvent } from "@/utility/amplitude";
 import { Button } from "@mui/material";
 
 function DeleteBoardButton() {
@@ -10,6 +11,7 @@ function DeleteBoardButton() {
 
     const handleDeleteBoardButtonClick = () => {
         (board.boardUUID) && mutate(board.boardUUID);
+        logEvent('delete_board');
         closeModal();
     }
 

--- a/src/components/atoms/Modal/BoardCreateModalElement.tsx
+++ b/src/components/atoms/Modal/BoardCreateModalElement.tsx
@@ -2,6 +2,7 @@ import { usePostCreateBoard } from "@/api/board";
 import theme from "@/assets/styles/theme";
 import { useModal } from "@/hooks/useModal";
 import { MAX_BOARD_DESCRIPTION_LENGTH, MAX_BOARD_TITLE_LENGTH, useIsBlank, useIsLessThanLengthLimitation } from "@/hooks/useValidation";
+import { logEvent } from "@/utility/amplitude";
 import { Typography, TextareaAutosize, Box, Chip, Button, FormHelperText } from "@mui/material";
 import { useState } from "react";
 
@@ -48,6 +49,7 @@ function BoardCreateModalElement() {
             description: description,
             tag: selectedTag,
         });
+        logEvent('create_board', { title: title, description: description, tag: selectedTag });
         closeModal();
     }
 

--- a/src/components/atoms/Modal/BoardCreateModalElement.tsx
+++ b/src/components/atoms/Modal/BoardCreateModalElement.tsx
@@ -49,7 +49,7 @@ function BoardCreateModalElement() {
             description: description,
             tag: selectedTag,
         });
-        logEvent('create_board', { title: title, description: description, tag: selectedTag });
+        logEvent('create_board', { tag: selectedTag });
         closeModal();
     }
 

--- a/src/components/atoms/Modal/BoardEditModalElement.tsx
+++ b/src/components/atoms/Modal/BoardEditModalElement.tsx
@@ -4,6 +4,7 @@ import DeleteBoardButton from "@/components/atoms/Board/DeleteBoardButton";
 import { useBoardAtom } from "@/hooks/useBoardAtom";
 import { useModal } from "@/hooks/useModal";
 import { MAX_BOARD_DESCRIPTION_LENGTH, MAX_BOARD_TITLE_LENGTH, useIsBlank, useIsLessThanLengthLimitation } from "@/hooks/useValidation";
+import { logEvent } from "@/utility/amplitude";
 import { Typography, TextareaAutosize, Box, Chip, Button, FormHelperText } from "@mui/material";
 import { useState } from "react";
 
@@ -53,6 +54,7 @@ function BoardEditModalElement() {
             tag: selectedTag,
             boardUUID: board.boardUUID,
         });
+        logEvent('edit_board');
         closeModal();
     }
 

--- a/src/components/atoms/Modal/LoginModalElement.tsx
+++ b/src/components/atoms/Modal/LoginModalElement.tsx
@@ -8,6 +8,7 @@ import kakaoLogo from '@/assets/icons/kakao_logo.png';
 
 import ColumnContainer from '@/components/atoms/ColumnContainer';
 import LoginButton from '@/components/atoms/LoginButton';
+import { logEvent } from '@/utility/amplitude';
 
 type TLoginProviderInformationElement = {
     url: string,
@@ -33,6 +34,7 @@ function LoginModalElement() {
     }
 
     const oAuthHandler = (loginProvider: string): void => {
+        logEvent('login', { loginProvider: loginProvider });
         window.location.href = loginProviderInformation[loginProvider].url;
     };
 

--- a/src/components/atoms/Modal/MemoCreateModalElement.tsx
+++ b/src/components/atoms/Modal/MemoCreateModalElement.tsx
@@ -28,7 +28,7 @@ function MemoCreateModalElement() {
 
     const handleCreateMemoButtonClick = () => {
         (token && scrapId && textAreaValue) && mutate({ token, scrapId, textAreaValue });
-        logEvent('create_memo', { scrapId: scrapId, textAreaValue: textAreaValue });
+        logEvent('create_memo');
         closeModal();
     }
 

--- a/src/components/atoms/Modal/MemoCreateModalElement.tsx
+++ b/src/components/atoms/Modal/MemoCreateModalElement.tsx
@@ -6,6 +6,7 @@ import { useModal } from '@/hooks/useModal';
 import { usePostCreateMemo } from '@/api/memo';
 import { useDefaultSnackbar } from '@/hooks/useWarningSnackbar';
 import { MAX_MEMO_LENGTH, useIsBlank, useIsEntered, useIsLessThanLengthLimitation } from '@/hooks/useValidation';
+import { logEvent } from '@/utility/amplitude';
 
 function MemoCreateModalElement() {
     const [, setToken] = useState<string | null>(null);
@@ -24,6 +25,12 @@ function MemoCreateModalElement() {
     const scrapId = modal.scrapId;
     const token = localStorage.getItem('token');
     const { mutate, isLoading, isError } = usePostCreateMemo();
+
+    const handleCreateMemoButtonClick = () => {
+        (token && scrapId && textAreaValue) && mutate({ token, scrapId, textAreaValue });
+        logEvent('create_memo', { scrapId: scrapId, textAreaValue: textAreaValue });
+        closeModal();
+    }
 
     if (isLoading) {
         return <CircularProgress
@@ -107,12 +114,7 @@ function MemoCreateModalElement() {
                         boxShadow: 'none',
                     }
                 }}
-                onClick={
-                    () => {
-                        (token && scrapId) && mutate({ token, scrapId, textAreaValue });
-                        closeModal();
-                    }
-                }
+                onClick={handleCreateMemoButtonClick}
                 disabled={!isValidationSuccess()}
             >
                 등록

--- a/src/components/atoms/Modal/ScrapCreateModalElement.tsx
+++ b/src/components/atoms/Modal/ScrapCreateModalElement.tsx
@@ -7,6 +7,7 @@ import { useModal } from '@/hooks/useModal';
 
 import { LinkIcon } from '@/components/atoms/Icon';
 import { SCRAP_LINK_MAX_LENGTH, useIsBlank, useIsEntered, useIsLessThanLengthLimitation, useIsValidURL, useIsWhiteSpaceExist } from '@/hooks/useValidation';
+import { logEvent } from '@/utility/amplitude';
 
 function ScrapCreateModalElement() {
     const [textAreaValue, setTextAreaValue] = useState('');
@@ -23,6 +24,11 @@ function ScrapCreateModalElement() {
     };
 
     const { mutate } = usePostCreateScrap();
+    const handleCreateScrapButtonClick = () => {
+        (token && textAreaValue) && mutate({ token, textAreaValue });
+        logEvent('create_scrap');
+        closeModal();
+    };
 
     const validation = () => {
         if (!useIsLessThanLengthLimitation(textAreaValue, SCRAP_LINK_MAX_LENGTH)) {
@@ -108,12 +114,7 @@ function ScrapCreateModalElement() {
                         }
                     }}
                     disabled={!isValidationSuccess()}
-                    onClick={
-                        () => {
-                            (token) && mutate({ token, textAreaValue });
-                            closeModal();
-                        }
-                    }
+                    onClick={handleCreateScrapButtonClick}
                 >
                     추가
                 </Button>

--- a/src/components/atoms/Modal/ScrapDeleteModalElement.tsx
+++ b/src/components/atoms/Modal/ScrapDeleteModalElement.tsx
@@ -1,6 +1,7 @@
 import { useDeleteScrap } from '@/api/scrap';
 import theme from '@/assets/styles/theme';
 import { useModal } from '@/hooks/useModal';
+import { logEvent } from '@/utility/amplitude';
 import { Box, Typography, Button } from '@mui/material';
 import { useState, useEffect } from 'react';
 
@@ -25,6 +26,12 @@ function ScrapDeleteElementModal() {
 
     const { modal, closeModal } = useModal();
     const { mutate } = useDeleteScrap();
+    const handleDeleteScrapButtonClick = () => {
+        const scrapId = modal.scrapId;
+        (token && scrapId) && mutate({ token, scrapId });
+        logEvent('delete_scrap');
+        closeModal();
+    }
 
     return (
         <Box
@@ -61,11 +68,7 @@ function ScrapDeleteElementModal() {
                 <Button
                     variant='contained'
                     sx={scrapDeleteModalButtonStyle}
-                    onClick={() => {
-                        const scrapId = modal.scrapId;
-                        (token && scrapId) && mutate({ token, scrapId });
-                        closeModal();
-                    }}
+                    onClick={handleDeleteScrapButtonClick}
                 >
                     삭제하기
                 </Button>

--- a/src/components/atoms/Modal/ScrapEditModalElement.tsx
+++ b/src/components/atoms/Modal/ScrapEditModalElement.tsx
@@ -5,6 +5,7 @@ import ThumbnailImage from "@/components/atoms/ThumbnailImage";
 import { useModal } from "@/hooks/useModal";
 import { useSelectedScrap } from "@/hooks/useSelectedScrap";
 import { MAX_SCRAP_AUTHOR_LENGTH, MAX_SCRAP_BLOGNAME_LENGTH, MAX_SCRAP_CHANNELNAME_LENGTH, MAX_SCRAP_DESCRIPTION_LENGTH, MAX_SCRAP_PRICE_LENGTH, MAX_SCRAP_SITENAME_LENGTH, MAX_SCRAP_TITLE_LENGTH, useIsBlank, useIsEntered, useIsLessThanLengthLimitation } from "@/hooks/useValidation";
+import { logEvent } from "@/utility/amplitude";
 import { Box, Button, FormControl, FormHelperText, TextareaAutosize, Typography } from "@mui/material";
 import { ChangeEvent, useEffect, useState } from "react";
 
@@ -171,6 +172,12 @@ function ScrapEditModalElement() {
 
     initiateEditableContent();
     const { mutate } = useEditScrap();
+    const handleEditScrapButtonClick = () => {
+        editScrap();
+        removeSelectedScrap();
+        closeModal();
+        logEvent('edit_scrap', { type: content.dtype });
+    }
 
     const editScrap = () => {
         for (const key in editalbeContent) {
@@ -359,11 +366,7 @@ function ScrapEditModalElement() {
                     lineHeight: '150%',
                     p: '8px 0',
                 }}
-                onClick={() => {
-                    closeModal();
-                    removeSelectedScrap();
-                    editScrap()
-                }}
+                onClick={handleEditScrapButtonClick}
                 disabled={!checkIsEveryValidationSuccessed()}
             >
                 변경하기

--- a/src/components/atoms/Modal/ScrapPasteModalElement.tsx
+++ b/src/components/atoms/Modal/ScrapPasteModalElement.tsx
@@ -1,12 +1,9 @@
 import { useGetScrapByType } from "@/api/scrap";
-import theme from "@/assets/styles/themeMuiStyle";
 import ScrapCard from "@/components/molcules/Board/ScrapCard";
 import SearchBar from "@/components/molcules/SearchBar";
-import MasonryListTemplate from "@/components/templates/MasonryListTemplate";
-import { useBoardAtom } from "@/hooks/useBoardAtom";
 import { useBoardContentAtom } from "@/hooks/useBoardContentAtom";
-import boardAtom from "@/state/boardAtom";
 import { contentProps } from "@/types/ContentType";
+import { logEvent } from "@/utility/amplitude";
 import { TabContext, TabPanel } from "@mui/lab";
 import { Box, CircularProgress, Tab, Tabs } from "@mui/material";
 import { useInfiniteQuery } from "@tanstack/react-query";
@@ -46,6 +43,11 @@ function ScrapPasteModalElement() {
                 }}
             />
         )
+    }
+
+    const handlePasteScrap = (content: contentProps['content']) => {
+        logEvent('paste_scrap', { type: content.dtype });
+        pasteScrap(content);
     }
 
     return (
@@ -92,9 +94,7 @@ function ScrapPasteModalElement() {
                             return page.data.content.map((content: contentProps['content']) => {
                                 return (
                                     <Box
-                                        onClick={() => {
-                                            pasteScrap(content);
-                                        }}
+                                        onClick={() => handlePasteScrap(content)}
                                     >
                                         <ScrapCard content={content} key={content.scrapId} />
                                     </Box>

--- a/src/components/atoms/Modal/StickerPasteModalElement.tsx
+++ b/src/components/atoms/Modal/StickerPasteModalElement.tsx
@@ -6,13 +6,23 @@ import { useModal } from '@/hooks/useModal';
 import { MAX_MEMO_LENGTH, useIsBlank, useIsEntered, useIsLessThanLengthLimitation } from '@/hooks/useValidation';
 import { useBoardContentAtom } from '@/hooks/useBoardContentAtom';
 import { useGetCurrentTimeInUnixTime } from '@/hooks/useCalculateDateDiff';
+import { logEvent } from '@/utility/amplitude';
 
 function StickerPasteModalElement() {
     const { closeModal } = useModal();
     const [textAreaValue, setTextAreaValue] = useState('');
-    const { pasteSticker } = useBoardContentAtom();
     const getCurrentTimeInUnixTime = useGetCurrentTimeInUnixTime();
 
+    const { pasteSticker } = useBoardContentAtom();
+    const handlePasteScrapButtonClick = () => {
+        pasteSticker({
+            memoId: getCurrentTimeInUnixTime,
+            memoText: textAreaValue,
+            createdDate: getCurrentTimeInUnixTime,
+        });
+        logEvent('paste_sticker');
+        closeModal();
+    }
     const handleSetValue = (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
         e.preventDefault();
         setTextAreaValue(e.target.value);
@@ -86,16 +96,7 @@ function StickerPasteModalElement() {
                         boxShadow: 'none',
                     }
                 }}
-                onClick={
-                    () => {
-                        pasteSticker({
-                            memoId: getCurrentTimeInUnixTime,
-                            memoText: textAreaValue,
-                            createdDate: getCurrentTimeInUnixTime,
-                        });
-                        closeModal();
-                    }
-                }
+                onClick={handlePasteScrapButtonClick}
                 disabled={!isValidationSuccess()}
             >
                 등록

--- a/src/components/atoms/Modal/UserDeleteModalElement.tsx
+++ b/src/components/atoms/Modal/UserDeleteModalElement.tsx
@@ -2,13 +2,19 @@ import { useDeleteUser } from '@/api/user';
 import theme from '@/assets/styles/theme';
 import { useGetToken } from '@/hooks/useAccount';
 import { useModal } from '@/hooks/useModal';
+import { logEvent } from '@amplitude/analytics-browser';
 import { Box, Button } from '@mui/material';
 import styled from 'styled-components';
 
 function UserDeleteModalElement() {
     const { closeModal } = useModal();
-    const { mutate } = useDeleteUser();
     const token = useGetToken();
+    const { mutate } = useDeleteUser();
+    const handleDeleteUserButtonClick = () => {
+        token && mutate(token);
+        logEvent('delete_user');
+        closeModal();
+    }
 
     const userDeleteModalButtonStyle = {
         backgroundColor: theme.color.Gray_050,
@@ -31,12 +37,7 @@ function UserDeleteModalElement() {
                     <Button
                         variant='contained'
                         sx={userDeleteModalButtonStyle}
-                        onClick={
-                            () => {
-                                token && mutate(token);
-                                closeModal();
-                            }
-                        }
+                        onClick={handleDeleteUserButtonClick}
                     >
                         탈퇴하기
                     </Button>

--- a/src/components/molcules/SearchBar.tsx
+++ b/src/components/molcules/SearchBar.tsx
@@ -1,12 +1,13 @@
 import { Box, Button, InputBase } from "@mui/material";
 
+import { useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+
 import theme from "@/assets/styles/theme";
+import { useIsBlank } from "@/hooks/useValidation";
+import { logEvent } from "@/utility/amplitude";
 
 import { SearchIcon } from "@/components/atoms/Icon";
-import { useEffect, useRef, useState } from "react";
-import { useGetScrapSearchResultByType } from "@/api/search";
-import { useNavigate, useSearchParams } from "react-router-dom";
-import { useIsBlank } from "@/hooks/useValidation";
 
 function SearchBar({ type }: { type: string }) {
     const [isSearched, setIsSearched] = useState(false);
@@ -23,6 +24,7 @@ function SearchBar({ type }: { type: string }) {
         isSearched: {
             text: '지우기',
             action: () => {
+                logEvent(`erase_search`);
                 setIsSearched(false);
                 setSearchText('');
                 navigate(`/scrap/${type}`);
@@ -31,6 +33,7 @@ function SearchBar({ type }: { type: string }) {
         isNotSearched: {
             text: '검색',
             action: () => {
+                logEvent(`search_${type}`, { keyword: searchText });
                 searchParams.append('keyword', searchText);
                 setSearchParams(searchParams);
                 setIsSearched(true);

--- a/src/components/organisms/EmptyScrapContainer.tsx
+++ b/src/components/organisms/EmptyScrapContainer.tsx
@@ -1,5 +1,6 @@
 import { useMoveToChromeExtensionInstallLink } from '@/hooks/useCustomNavigation';
 import { useModal } from '@/hooks/useModal';
+import { logEvent } from '@/utility/amplitude';
 import { Box, Button, Typography } from '@mui/material';
 
 function EmptyScrapContainer() {
@@ -10,6 +11,7 @@ function EmptyScrapContainer() {
 
     const { openModal } = useModal();
     const openScrapCreateModalHandler = () => {
+        logEvent('scrapCreate', { from: 'emptyScrapContainer' });
         openModal('scrapCreate');
     }
 

--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -1,7 +1,9 @@
+import { logEvent } from "@/utility/amplitude";
 import { useNavigate } from "react-router-dom";
 
 export function useLogout() {
     const navigate = useNavigate();
+    logEvent('logout');
     return () => {
         localStorage.removeItem('token');
         localStorage.removeItem('profileImageURL');

--- a/src/hooks/useCustomNavigation.ts
+++ b/src/hooks/useCustomNavigation.ts
@@ -1,5 +1,8 @@
+import { logEvent } from "@/utility/amplitude";
+
 const chromeExtensionInstallLink = 'https://chrome.google.com/webstore/detail/dadamda/kgaiabolccidmgihificdfaimdlfmcfj?hl=ko';
 
 export function useMoveToChromeExtensionInstallLink() {
+    logEvent('chrome_extension_install_link_click');
     location.href = chromeExtensionInstallLink;
 }

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -13,6 +13,7 @@ import ScrapPasteModalElement from "@/components/atoms/Modal/ScrapPasteModalElem
 import BoardCreateModalElement from "@/components/atoms/Modal/BoardCreateModalElement";
 import StickerPasteModalElement from "@/components/atoms/Modal/StickerPasteModalElement";
 import BoardEditModalElement from "@/components/atoms/Modal/BoardEditModalElement";
+import { logEvent } from "@/utility/amplitude";
 
 export const useModal = () => {
     const [modal, setModal] = useAtom(modalAtom);
@@ -84,6 +85,7 @@ export const useModal = () => {
         type: string
     ) => {
         setModal((prev) => {
+            logEvent(`open_${type}_modal`);
             return {
                 ...prev,
                 ...modalTypeMatching[type as keyof typeof modalTypeMatching],


### PR DESCRIPTION
## 개요
- DAD-917
- DAD-972
- DAD-973
- DAD-974

## 작업사항
- 검색 버튼, 메모/스크랩 추가/삭제/편집 버튼에 amplitude 추가 -> 스크랩 type 추가
- 보드 추가/편집/삭제/스크랩 붙여넣기/스티커 붙여넣기에 amplitude 추가 -> 보드 태그, 스크랩 type 추가
- 크롬 익스텐션 설치하기 버튼에 amplitude 추가
- 구글 로그인 / 카카오 로그인에 amplitude 추가 -> loginProvider 추가

## 변경로직(Optional)
- 일부 버튼들 onClick 바로 콜백으로 구현했었는데 별도 handler로 분리함.