### PR TITLE
[DAD-946] 보드 썸네일 이미지 추가 (다나😘)

### DIFF
--- a/src/components/atoms/Modal/ScrapPasteModalElement.tsx
+++ b/src/components/atoms/Modal/ScrapPasteModalElement.tsx
@@ -3,6 +3,7 @@ import { useGetScrapSearchResultByType } from "@/api/search";
 import ScrapCard from "@/components/molcules/Board/ScrapCard";
 import SearchBar from "@/components/molcules/SearchBar";
 import { useBoardContentAtom } from "@/hooks/useBoardContentAtom";
+import { useDefaultSnackbar } from "@/hooks/useWarningSnackbar";
 import { contentProps } from "@/types/ContentType";
 import { logEvent } from "@/utility/amplitude";
 import { TabContext, TabPanel } from "@mui/lab";
@@ -72,6 +73,7 @@ function ScrapPasteModalElement() {
     const handlePasteScrap = (content: contentProps['content']) => {
         logEvent('paste_scrap', { type: content.dtype });
         pasteScrap(content);
+        useDefaultSnackbar('스크랩이 추가되었습니다.', 'success');
     }
 
     return (

--- a/src/components/atoms/Modal/ScrapPasteModalElement.tsx
+++ b/src/components/atoms/Modal/ScrapPasteModalElement.tsx
@@ -98,7 +98,6 @@ function ScrapPasteModalElement() {
                     <Tab label="상품" value='product' />
                     <Tab label="아티클" value='article' />
                     <Tab label="비디오" value='video' />
-                    <Tab label="장소" value='place' disabled />
                 </Tabs>
                 <TabPanel
                     value={value}

--- a/src/components/molcules/Navigation/Header.tsx
+++ b/src/components/molcules/Navigation/Header.tsx
@@ -19,6 +19,10 @@ const headerPanelMenus = [{
     link: '/main',
 }, {
     isVisibleWithoutLogin: false,
+    name: '보드',
+    link: '/board',
+}, {
+    isVisibleWithoutLogin: false,
     name: '스크랩북',
     link: '/scrap/list',
 }];

--- a/src/components/molcules/Navigation/MobileNavbar.tsx
+++ b/src/components/molcules/Navigation/MobileNavbar.tsx
@@ -46,6 +46,13 @@ function MobileNavbar({ toggleMobileNavbar }: MobileNavbarProps) {
     },
   }, {
     isVisibleWithoutLogin: false,
+    name: '보드',
+    onclick: () => {
+      navigate('/board');
+      toggleMobileNavbar();
+    },
+  }, {
+    isVisibleWithoutLogin: false,
     name: '스크랩',
     onclick: () => toggleMenu(),
     isMenuOpen: true,

--- a/src/components/molcules/Navigation/Navbar.tsx
+++ b/src/components/molcules/Navigation/Navbar.tsx
@@ -1,10 +1,8 @@
-import styled from 'styled-components';
-
 import theme from '../../../assets/styles/theme';
-import { Link, useLocation } from 'react-router-dom';
-import { Box, MenuItem, Typography } from '@mui/material';
+import { useLocation } from 'react-router-dom';
+import { Box, Typography } from '@mui/material';
 
-import { BoardIcon, TotalIcon, ArticleIcon, ProductIcon, VideoIcon, LocationIcon, EtcIcon } from '../../atoms/Icon';
+import { BoardIcon } from '../../atoms/Icon';
 import ColumnContainer from '../../atoms/ColumnContainer';
 import ScrapNaviagtion from './ScrapNaviagtion';
 import NavigationMenuItem from '../../atoms/Navigation/NavigationMenuItem';
@@ -39,6 +37,17 @@ function Navbar() {
                     sx={{
                         fontWeight: '600',
                         mb: '8px',
+                    }}>
+                    보드
+                </Typography>
+                <NavigationMenuItem item={boardMenuItem} isActive={pathname === boardMenuItem.link} />
+                <Typography
+                    variant='h5'
+                    color={theme.color.Gray_080}
+                    sx={{
+                        fontWeight: '600',
+                        mb: '8px',
+                        mt: '32px',
                     }}>
                     스크랩
                 </Typography>

--- a/src/components/templates/BoardListTemplate.tsx
+++ b/src/components/templates/BoardListTemplate.tsx
@@ -136,7 +136,18 @@ function BoardListTemplate() {
                                                     alignItems: 'center',
                                                 }}
                                             >
-                                                <Typography>{board.title}</Typography>
+                                                <Typography
+                                                    sx={{
+                                                        overflow: 'hidden',
+                                                        textOverflow: 'ellipsis',
+                                                        display: '-webkit-box',
+                                                        '-webkit-line-clamp': '1',
+                                                        '-webkit-box-orient': 'vertical',
+                                                        wordWrap: 'break-word',
+                                                    }}
+                                                >
+                                                    {board.title}
+                                                </Typography>
                                                 <Box
                                                     sx={{
                                                         display: 'flex',

--- a/src/components/templates/BoardListTemplate.tsx
+++ b/src/components/templates/BoardListTemplate.tsx
@@ -6,7 +6,7 @@ import theme from '@/assets/styles/theme';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useFixBoardList, useGetBoard, useGetBoardList, useSearchKeywordInBoardList } from '@/api/board';
-import { MenuIcon, StarIcon } from '@/components/atoms/Icon';
+import { MenuIcon, ProfileIcon, StarIcon } from '@/components/atoms/Icon';
 import { getTimeDiff } from '@/hooks/useCalculateDateDiff';
 import { useModal } from '@/hooks/useModal';
 import { useBoardAtom } from '@/hooks/useBoardAtom';
@@ -86,6 +86,7 @@ function BoardListTemplate() {
                             m: '0',
                             display: 'grid',
                             gap: 2,
+                            pb: '24px',
                         }}
                         gridTemplateColumns={
                             {
@@ -114,8 +115,12 @@ function BoardListTemplate() {
                                                 '&:hover': {
                                                     backgroundColor: theme.color.Blue_080,
                                                 },
+                                                display: 'flex',
+                                                justifyContent: 'center',
+                                                alignItems: 'center',
                                             }}
                                         >
+                                            <ProfileIcon size='80' />
                                         </Box>
                                         <Box
                                             sx={{

--- a/src/pages/BoardInfoPage.tsx
+++ b/src/pages/BoardInfoPage.tsx
@@ -154,7 +154,10 @@ function BoardInfoPage() {
                 )
                     : (
                         <Button
-                            onClick={() => setMode('view')}
+                            onClick={() => {
+                                setMode('view')
+                                handleSaveBoard('edit')
+                            }}
                         >
                             보기 모드
                         </Button>

--- a/src/pages/BoardInfoPage.tsx
+++ b/src/pages/BoardInfoPage.tsx
@@ -168,9 +168,6 @@ function BoardInfoPage() {
                 >
                     저장
                 </Button>
-                <Button>
-                    공유
-                </Button>
                 <Button
                     onClick={() => openModal('boardEdit')}
                 >


### PR DESCRIPTION
## 개요
- DAD-949 : 보드 썸네일 이미지 추가
- DAD-983 : 스크랩 paste 모달에서 '장소' 키워드 제거

## 작업사항
- 보드 목록 페이지에서 하단 여백 영역 추가
- 보드 목록 페이지에서 보드 이름이 너무 길 경우 ... 처리 (피그마 참고)
- 스크랩 paste 성공 알리는 toast 추가
- 보드 contents 페이지에서 편집모드 -> 보기 모드로 전환시 save board 함수 호출