### PR TITLE
[DAD-1138] 유저 페이지 api 연결

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -155,7 +155,7 @@ export const useUploadUserProfileImage = () => {
 				"error"
 			);
 		},
-		useErrorBoundary: true,
+		useErrorBoundary: false,
 		retry: false,
 	});
 
@@ -252,7 +252,7 @@ export const useDeleteUserProfileImage = () => {
 				"error"
 			);
 		},
-		useErrorBoundary: true,
+		useErrorBoundary: false,
 		retry: false,
 	});
 

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -94,24 +94,23 @@ export const useGetUserInformation = () => {
 	return { userInformation, isGetUserInformationLoading };
 };
 
-// const changeFileToMultiPartFormData = (file: File) => {
-
-// 	return formData;
-// };
+const changeFileToMultiPartFormData = (file: File) => {
+	const formData = new FormData();
+	formData.append("file", file);
+	return formData;
+};
 
 const uploadUserProfileImage = (file: File) => {
 	const token = useGetToken();
 
-	const formData = new FormData();
-	formData.append("file", file);
-	// const fileFormData = changeFileToMultiPartFormData(file);
+	const fileFormData = changeFileToMultiPartFormData(file);
 
 	const response = fetch(UPLOAD_USER_PROFILE_IMAGE_URL, {
 		method: "POST",
 		headers: {
 			"X-AUTH-TOKEN": token,
 		},
-		body: formData,
+		body: fileFormData,
 	}).then((response) => {
 		return response.json().then((body) => {
 			if (response.ok) {

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -102,6 +102,17 @@ const changeFileToMultiPartFormData = (file: File) => {
 	return formData;
 };
 
+const previewUploadImage = (file: File) => {
+	const reader = new FileReader();
+	reader.readAsDataURL(file);
+	reader.onloadend = () => {
+		localStorage.setItem(
+			"profileImageURL",
+			reader.result as string
+		);
+	};
+};
+
 const uploadUserProfileImage = (file: File) => {
 	const token = useGetToken();
 
@@ -116,6 +127,7 @@ const uploadUserProfileImage = (file: File) => {
 	}).then((response) => {
 		return response.json().then((body) => {
 			if (response.ok) {
+				previewUploadImage(file);
 				return body;
 			} else {
 				throw new Error(body.resultCode);
@@ -126,7 +138,7 @@ const uploadUserProfileImage = (file: File) => {
 	return response;
 };
 
-export const useUploadUserProfileImage = () => {
+export const useUploadUserProfileImage = (file: File) => {
 	const queryClient = useQueryClient();
 	const { mutate } = useMutation(uploadUserProfileImage, {
 		onSuccess: () => {
@@ -206,7 +218,7 @@ export const useEditUserNickname = () => {
 const deleteUserProfileImage = async () => {
 	const token = useGetToken();
 
-	const response = await fetch(DELETE_USER_PROFILE_IMAGE_URL, {
+	return await fetch(DELETE_USER_PROFILE_IMAGE_URL, {
 		method: "DELETE",
 		headers: {
 			"X-AUTH-TOKEN": token,
@@ -220,8 +232,6 @@ const deleteUserProfileImage = async () => {
 			}
 		});
 	});
-
-	return response;
 };
 
 export const useDeleteUserProfileImage = () => {
@@ -233,6 +243,7 @@ export const useDeleteUserProfileImage = () => {
 				"프로필 이미지가 삭제되었습니다.",
 				"success"
 			);
+			localStorage.setItem("profileImageURL", "");
 		},
 		onError: (error) => {
 			Sentry.captureException(error);

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,87 +1,151 @@
 import { useGetToken, useLogout } from "@/hooks/useAccount";
 import { useDefaultSnackbar } from "@/hooks/useWarningSnackbar";
-import { DELETE_USER_URL, GET_USER_INFORMATION_URL } from "@/secret";
+import {
+	DELETE_USER_URL,
+	GET_USER_INFORMATION_URL,
+	UPLOAD_USER_PROFILE_IMAGE_URL,
+} from "@/secret";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import * as Sentry from '@sentry/react';
+import * as Sentry from "@sentry/react";
 
 const fetchDeleteUser = async () => {
-    const token = useGetToken();
+	const token = useGetToken();
 
-    const response = await fetch(DELETE_USER_URL, {
-        method: "DELETE",
-        headers: {
-            "Content-Type": "application/json",
-            "X-AUTH-TOKEN": token,
-        },
-    })
-    .then(async (response) => {
-        const body = await response.json();
-        if (response.ok) {
-            return body;
-        } else {
-            throw new Error(body.resultCode);
-        }
-    })
+	const response = await fetch(DELETE_USER_URL, {
+		method: "DELETE",
+		headers: {
+			"Content-Type": "application/json",
+			"X-AUTH-TOKEN": token,
+		},
+	}).then(async (response) => {
+		const body = await response.json();
+		if (response.ok) {
+			return body;
+		} else {
+			throw new Error(body.resultCode);
+		}
+	});
 
-    return response;
-}
+	return response;
+};
 
 export const useDeleteUser = () => {
-    const queryClient = useQueryClient();
-    const logout = useLogout();
-    return useMutation(fetchDeleteUser, {
-        onSuccess: () => {
-            queryClient.invalidateQueries(['user']);
-            logout();
-            useDefaultSnackbar('회원 탈퇴에 성공했습니다', 'success');
-        },
-        onError: (error) => {
-            Sentry.captureException(error);
-            useDefaultSnackbar('회원 탈퇴에 실패했습니다', 'error');
-        },
-        useErrorBoundary: true,
-    });
-}
+	const queryClient = useQueryClient();
+	const logout = useLogout();
+	return useMutation(fetchDeleteUser, {
+		onSuccess: () => {
+			queryClient.invalidateQueries(["user"]);
+			logout();
+			useDefaultSnackbar(
+				"회원 탈퇴에 성공했습니다",
+				"success"
+			);
+		},
+		onError: (error) => {
+			Sentry.captureException(error);
+			useDefaultSnackbar("회원 탈퇴에 실패했습니다", "error");
+		},
+		useErrorBoundary: true,
+	});
+};
 
 const getUserInformation = async () => {
-    const token = useGetToken();
+	const token = useGetToken();
 
-    const response = await fetch(GET_USER_INFORMATION_URL, {
-        method: "GET",
-        headers: {
-            "Content-Type": "application/json",
-            "X-AUTH-TOKEN": token,
-        },
-    }).then((response) => {
-            return response.json().then(body => {
-                if (response.ok) {
-                    return body;
-                } else {
-                    throw new Error(body.resultCode);
-                }
-            })
-        });
+	const response = await fetch(GET_USER_INFORMATION_URL, {
+		method: "GET",
+		headers: {
+			"Content-Type": "application/json",
+			"X-AUTH-TOKEN": token,
+		},
+	}).then((response) => {
+		return response.json().then((body) => {
+			if (response.ok) {
+				return body;
+			} else {
+				throw new Error(body.resultCode);
+			}
+		});
+	});
 
-    return response;
-}
+	return response;
+};
 
 export const useGetUserInformation = () => {
-    const { data, isLoading } = useQuery(
-        ['userInformation'], 
-        () => getUserInformation(), 
-        {
-            retry: false,
-            select: (data) => {
-                return data.data;
-            },
-            onError: (error) => {
-                Sentry.captureException(error);
-            },
-            useErrorBoundary: true,
-        }
-    );
+	const { data, isLoading } = useQuery(
+		["userInformation"],
+		() => getUserInformation(),
+		{
+			retry: false,
+			select: (data) => {
+				return data.data;
+			},
+			onError: (error) => {
+				Sentry.captureException(error);
+			},
+			useErrorBoundary: true,
+		}
+	);
 
-    const [userInformation, isGetUserInformationLoading] = [data, isLoading];
-    return { userInformation, isGetUserInformationLoading};
+	const [userInformation, isGetUserInformationLoading] = [
+		data,
+		isLoading,
+	];
+	return { userInformation, isGetUserInformationLoading };
 };
-        
+
+// const changeFileToMultiPartFormData = (file: File) => {
+
+// 	return formData;
+// };
+
+const uploadUserProfileImage = (file: File) => {
+	const token = useGetToken();
+
+	const formData = new FormData();
+	formData.append("file", file);
+	// const fileFormData = changeFileToMultiPartFormData(file);
+
+	const response = fetch(UPLOAD_USER_PROFILE_IMAGE_URL, {
+		method: "POST",
+		headers: {
+			"X-AUTH-TOKEN": token,
+		},
+		body: formData,
+	}).then((response) => {
+		return response.json().then((body) => {
+			if (response.ok) {
+				return body;
+			} else {
+				throw new Error(body.resultCode);
+			}
+		});
+	});
+
+	return response;
+};
+
+export const useUploadUserProfileImage = () => {
+	const queryClient = useQueryClient();
+	const { mutate } = useMutation(uploadUserProfileImage, {
+		onSuccess: () => {
+			queryClient.invalidateQueries(["userInformation"]);
+			useDefaultSnackbar(
+				"프로필 이미지가 변경되었습니다.",
+				"success"
+			);
+		},
+		onError: (error) => {
+			Sentry.captureException(error);
+			useDefaultSnackbar(
+				"프로필 이미지 변경에 실패했습니다",
+				"error"
+			);
+		},
+		useErrorBoundary: true,
+		retry: false,
+	});
+
+	const uploadUserProfileImageMutate = mutate;
+	return { uploadUserProfileImageMutate };
+};

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -236,7 +236,7 @@ const deleteUserProfileImage = async () => {
 
 export const useDeleteUserProfileImage = () => {
 	const queryClient = useQueryClient();
-	const { mutate } = useMutation(deleteUserProfileImage, {
+	const { mutate, isSuccess } = useMutation(deleteUserProfileImage, {
 		onSuccess: () => {
 			queryClient.invalidateQueries(["userInformation"]);
 			useDefaultSnackbar(
@@ -256,6 +256,12 @@ export const useDeleteUserProfileImage = () => {
 		retry: false,
 	});
 
-	const deleteUserProfileImageMutate = mutate;
-	return { deleteUserProfileImageMutate };
+	const [
+		deleteUserProfileImageMutate,
+		isDeleteUserProfileImageMutateSuccess,
+	] = [mutate, isSuccess];
+	return {
+		deleteUserProfileImageMutate,
+		isDeleteUserProfileImageMutateSuccess,
+	};
 };

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,6 +1,7 @@
 import { useGetToken, useLogout } from "@/hooks/useAccount";
 import { useDefaultSnackbar } from "@/hooks/useWarningSnackbar";
 import {
+	DELETE_USER_PROFILE_IMAGE_URL,
 	DELETE_USER_URL,
 	EDIT_USER_NICKNAME_URL,
 	GET_USER_INFORMATION_URL,
@@ -200,4 +201,50 @@ export const useEditUserNickname = () => {
 		},
 		retry: false,
 	});
+};
+
+const deleteUserProfileImage = async () => {
+	const token = useGetToken();
+
+	const response = await fetch(DELETE_USER_PROFILE_IMAGE_URL, {
+		method: "DELETE",
+		headers: {
+			"X-AUTH-TOKEN": token,
+		},
+	}).then((response) => {
+		return response.json().then((body) => {
+			if (response.ok) {
+				return body;
+			} else {
+				throw new Error(body.resultCode);
+			}
+		});
+	});
+
+	return response;
+};
+
+export const useDeleteUserProfileImage = () => {
+	const queryClient = useQueryClient();
+	const { mutate } = useMutation(deleteUserProfileImage, {
+		onSuccess: () => {
+			queryClient.invalidateQueries(["userInformation"]);
+			useDefaultSnackbar(
+				"프로필 이미지가 삭제되었습니다.",
+				"success"
+			);
+		},
+		onError: (error) => {
+			Sentry.captureException(error);
+			useDefaultSnackbar(
+				"프로필 이미지 삭제에 실패했습니다",
+				"error"
+			);
+		},
+		useErrorBoundary: true,
+		retry: false,
+	});
+
+	const deleteUserProfileImageMutate = mutate;
+	return { deleteUserProfileImageMutate };
 };

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -138,7 +138,7 @@ const uploadUserProfileImage = (file: File) => {
 	return response;
 };
 
-export const useUploadUserProfileImage = (file: File) => {
+export const useUploadUserProfileImage = () => {
 	const queryClient = useQueryClient();
 	const { mutate } = useMutation(uploadUserProfileImage, {
 		onSuccess: () => {

--- a/src/components/molcules/UserPage/UserImageChangeWrapper.tsx
+++ b/src/components/molcules/UserPage/UserImageChangeWrapper.tsx
@@ -9,6 +9,7 @@ import { IMAGE_FILE_SIZE_LIMITATION, useIsFileSizeLessThanLimitation, useIsFileT
 import theme from "@/assets/styles/theme";
 import { useDeleteUserProfileImage, useUploadUserProfileImage } from "@/api/user";
 import { useDefaultSnackbar } from "@/hooks/useWarningSnackbar";
+import { ProfileIcon } from "@/components/atoms/Icon";
 
 function UserImageChangeWrapper({ mode, profileUrl }: { mode: string, profileUrl?: string }) {
     const [requestPrevieFile, file] = useGetPreviewFile();
@@ -50,9 +51,12 @@ function UserImageChangeWrapper({ mode, profileUrl }: { mode: string, profileUrl
     }
 
     const { uploadUserProfileImageMutate } = useUploadUserProfileImage();
-    const { deleteUserProfileImageMutate } = useDeleteUserProfileImage();
+    const { deleteUserProfileImageMutate, isDeleteUserProfileImageMutateSuccess } = useDeleteUserProfileImage();
     const handleRemoveImage = () => {
         deleteUserProfileImageMutate();
+        if (isDeleteUserProfileImageMutateSuccess) {
+            setImage(undefined);
+        }
     }
 
     const handleUploadUserProfileImage = (file: File | null) => {
@@ -64,7 +68,7 @@ function UserImageChangeWrapper({ mode, profileUrl }: { mode: string, profileUrl
         uploadUserProfileImageMutate(file);
     }
 
-    function ProfileImage({ src }: { src: string }) {
+    function ProfileImage({ src }: { src?: string }) {
         return <Box
             onClick={requestPrevieFile}
             sx={{
@@ -78,16 +82,24 @@ function UserImageChangeWrapper({ mode, profileUrl }: { mode: string, profileUrl
                 },
             }}
         >
-            <img
-                src={src}
-                alt="프로필 이미지"
-                style={{
-                    width: '200px',
-                    height: '200px',
-                    borderRadius: '100%',
-                }}
-                className="profile-image"
-            />
+            {
+                src
+                    ? <img
+                        src={src}
+                        alt="프로필 이미지"
+                        style={{
+                            width: '200px',
+                            height: '200px',
+                            borderRadius: '100%',
+                        }}
+                        className="profile-image"
+                    />
+                    : <Box
+                        className="profile-image"
+                    >
+                        <ProfileIcon size="200" />
+                    </Box>
+            }
             <Typography
                 sx={{
                     position: 'absolute',
@@ -111,10 +123,7 @@ function UserImageChangeWrapper({ mode, profileUrl }: { mode: string, profileUrl
             }}
         >
             <Box>
-                {image
-                    ? <ProfileImage src={image} />
-                    : <ProfileImage src={defaultUserImage} />
-                }
+                <ProfileImage src={image} />
                 {useIsUserPageEditMode(mode) &&
                     <Box
                         sx={{

--- a/src/components/molcules/UserPage/UserImageChangeWrapper.tsx
+++ b/src/components/molcules/UserPage/UserImageChangeWrapper.tsx
@@ -1,18 +1,94 @@
-import { grayOutlinedButtonStyle, grayFullfilledButtonStyle, useIsUserPageEditMode } from "@/pages/UserPage";
-import { Box, Button } from "@mui/material";
+import { Box, Button, Typography } from "@mui/material";
+import { useEffect, useState } from "react";
+
 import defaultUserImage from '@/assets/images/Avatar.png';
+import useGetPreviewFile from "@/hooks/useGetPrevieFile";
+
+import { grayOutlinedButtonStyle, grayFullfilledButtonStyle, useIsUserPageEditMode } from "@/pages/UserPage";
+import { IMAGE_FILE_SIZE_LIMITATION, useIsFileSizeLessThanLimitation, useIsFileTypeImage } from "@/hooks/useValidation";
+import theme from "@/assets/styles/theme";
 
 function UserImageChangeWrapper({ mode, profileUrl }: { mode: string, profileUrl?: string }) {
+    const [requestPrevieFile, file] = useGetPreviewFile();
+    const [image, setImage] = useState(profileUrl);
+
+    useEffect(() => {
+        if (!file) {
+            return;
+        }
+
+        const validateImageErrorMessage = getValidateImageErrorMessage(file);
+        if (validateImageErrorMessage) {
+            alert(validateImageErrorMessage);
+            return;
+        }
+
+        previewUploadImage(file);
+    }, [file]);
+
+    const getValidateImageErrorMessage = (file: File) => {
+        let error = '';
+        if (!useIsFileSizeLessThanLimitation(file, IMAGE_FILE_SIZE_LIMITATION)) {
+            error = '파일 용량이 너무 큽니다.';
+        }
+
+        if (!useIsFileTypeImage(file)) {
+            error = '이미지 파일만 업로드 가능합니다.';
+        }
+
+        return error;
+    }
+
+    const previewUploadImage = (file: File) => {
+        const reader = new FileReader();
+        reader.readAsDataURL(file);
+        reader.onloadend = () => {
+            setImage(reader.result as string);
+        }
+    }
+
+    const handleRemoveImage = () => {
+        setImage('');
+    }
+
     function ProfileImage({ src }: { src: string }) {
-        return <img
-            src={src}
-            alt="프로필 이미지"
-            style={{
-                width: '200px',
-                height: '200px',
-                borderRadius: '100%',
+        return <Box
+            onClick={requestPrevieFile}
+            sx={{
+                position: 'relative',
+                cursor: 'pointer',
+                '&:hover .MuiTypography-root': {
+                    display: 'block',
+                },
+                '&:hover .profile-image': {
+                    filter: 'brightness(0.5)',
+                },
             }}
-        />
+        >
+            <img
+                src={src}
+                alt="프로필 이미지"
+                style={{
+                    width: '200px',
+                    height: '200px',
+                    borderRadius: '100%',
+                }}
+                className="profile-image"
+            />
+            <Typography
+                sx={{
+                    position: 'absolute',
+                    top: '50%',
+                    left: '50%',
+                    transform: 'translate(-50%, -50%)',
+                    display: 'none',
+                    zIndex: 1,
+                    color: theme.color.Blue_050,
+                }}
+            >
+                이미지 선택
+            </Typography>
+        </Box>
     }
     return (
         <Box
@@ -22,8 +98,8 @@ function UserImageChangeWrapper({ mode, profileUrl }: { mode: string, profileUrl
             }}
         >
             <Box>
-                {profileUrl
-                    ? <ProfileImage src={profileUrl} />
+                {image
+                    ? <ProfileImage src={image} />
                     : <ProfileImage src={defaultUserImage} />
                 }
                 {useIsUserPageEditMode(mode) &&
@@ -36,8 +112,17 @@ function UserImageChangeWrapper({ mode, profileUrl }: { mode: string, profileUrl
                             mt: '24px',
                         }}
                     >
-                        <Button sx={grayOutlinedButtonStyle}>이미지 변경</Button>
-                        <Button sx={grayFullfilledButtonStyle}>이미지 삭제</Button>
+                        <Button
+                            sx={grayOutlinedButtonStyle}
+                        >
+                            이미지 변경
+                        </Button>
+                        <Button
+                            sx={grayFullfilledButtonStyle}
+                            onClick={handleRemoveImage}
+                        >
+                            이미지 삭제
+                        </Button>
                     </Box>
                 }
             </Box>

--- a/src/components/molcules/UserPage/UserImageChangeWrapper.tsx
+++ b/src/components/molcules/UserPage/UserImageChangeWrapper.tsx
@@ -53,7 +53,6 @@ function UserImageChangeWrapper({ mode, profileUrl }: { mode: string, profileUrl
     const { deleteUserProfileImageMutate } = useDeleteUserProfileImage();
     const handleRemoveImage = () => {
         deleteUserProfileImageMutate();
-        // setImage('');
     }
 
     const handleUploadUserProfileImage = (file: File | null) => {

--- a/src/components/molcules/UserPage/UserImageChangeWrapper.tsx
+++ b/src/components/molcules/UserPage/UserImageChangeWrapper.tsx
@@ -1,0 +1,48 @@
+import { grayOutlinedButtonStyle, grayFullfilledButtonStyle, useIsUserPageEditMode } from "@/pages/UserPage";
+import { Box, Button } from "@mui/material";
+import defaultUserImage from '@/assets/images/Avatar.png';
+
+function UserImageChangeWrapper({ mode, profileUrl }: { mode: string, profileUrl?: string }) {
+    function ProfileImage({ src }: { src: string }) {
+        return <img
+            src={src}
+            alt="프로필 이미지"
+            style={{
+                width: '200px',
+                height: '200px',
+                borderRadius: '100%',
+            }}
+        />
+    }
+    return (
+        <Box
+            sx={{
+                position: 'absolute',
+                top: '-25%',
+            }}
+        >
+            <Box>
+                {profileUrl
+                    ? <ProfileImage src={profileUrl} />
+                    : <ProfileImage src={defaultUserImage} />
+                }
+                {useIsUserPageEditMode(mode) &&
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            width: '100%',
+                            justifyContent: 'center',
+                            gap: '8px',
+                            mt: '24px',
+                        }}
+                    >
+                        <Button sx={grayOutlinedButtonStyle}>이미지 변경</Button>
+                        <Button sx={grayFullfilledButtonStyle}>이미지 삭제</Button>
+                    </Box>
+                }
+            </Box>
+        </Box>
+    );
+}
+
+export default UserImageChangeWrapper;

--- a/src/components/molcules/UserPage/UserImageChangeWrapper.tsx
+++ b/src/components/molcules/UserPage/UserImageChangeWrapper.tsx
@@ -1,15 +1,14 @@
 import { Box, Button, Typography } from "@mui/material";
 import { useEffect, useState } from "react";
 
-import defaultUserImage from '@/assets/images/Avatar.png';
 import useGetPreviewFile from "@/hooks/useGetPrevieFile";
-
-import { grayOutlinedButtonStyle, grayFullfilledButtonStyle, useIsUserPageEditMode } from "@/pages/UserPage";
 import { IMAGE_FILE_SIZE_LIMITATION, useIsFileSizeLessThanLimitation, useIsFileTypeImage } from "@/hooks/useValidation";
 import theme from "@/assets/styles/theme";
 import { useDeleteUserProfileImage, useUploadUserProfileImage } from "@/api/user";
 import { useDefaultSnackbar } from "@/hooks/useWarningSnackbar";
+
 import { ProfileIcon } from "@/components/atoms/Icon";
+import { grayOutlinedButtonStyle, grayFullfilledButtonStyle, useIsUserPageEditMode } from "@/pages/UserPage";
 
 function UserImageChangeWrapper({ mode, profileUrl }: { mode: string, profileUrl?: string }) {
     const [requestPrevieFile, file] = useGetPreviewFile();

--- a/src/components/molcules/UserPage/UserImageChangeWrapper.tsx
+++ b/src/components/molcules/UserPage/UserImageChangeWrapper.tsx
@@ -7,6 +7,8 @@ import useGetPreviewFile from "@/hooks/useGetPrevieFile";
 import { grayOutlinedButtonStyle, grayFullfilledButtonStyle, useIsUserPageEditMode } from "@/pages/UserPage";
 import { IMAGE_FILE_SIZE_LIMITATION, useIsFileSizeLessThanLimitation, useIsFileTypeImage } from "@/hooks/useValidation";
 import theme from "@/assets/styles/theme";
+import { useUploadUserProfileImage } from "@/api/user";
+import { useDefaultSnackbar } from "@/hooks/useWarningSnackbar";
 
 function UserImageChangeWrapper({ mode, profileUrl }: { mode: string, profileUrl?: string }) {
     const [requestPrevieFile, file] = useGetPreviewFile();
@@ -47,8 +49,19 @@ function UserImageChangeWrapper({ mode, profileUrl }: { mode: string, profileUrl
         }
     }
 
+    const { uploadUserProfileImageMutate } = useUploadUserProfileImage();
+
     const handleRemoveImage = () => {
         setImage('');
+    }
+
+    const handleUploadUserProfileImage = (file: File | null) => {
+        if (!file) {
+            useDefaultSnackbar('이미지를 선택해주세요.', 'error');
+            return;
+        }
+
+        uploadUserProfileImageMutate(file);
     }
 
     function ProfileImage({ src }: { src: string }) {
@@ -114,6 +127,7 @@ function UserImageChangeWrapper({ mode, profileUrl }: { mode: string, profileUrl
                     >
                         <Button
                             sx={grayOutlinedButtonStyle}
+                            onClick={() => handleUploadUserProfileImage(file)}
                         >
                             이미지 변경
                         </Button>

--- a/src/components/molcules/UserPage/UserImageChangeWrapper.tsx
+++ b/src/components/molcules/UserPage/UserImageChangeWrapper.tsx
@@ -7,7 +7,7 @@ import useGetPreviewFile from "@/hooks/useGetPrevieFile";
 import { grayOutlinedButtonStyle, grayFullfilledButtonStyle, useIsUserPageEditMode } from "@/pages/UserPage";
 import { IMAGE_FILE_SIZE_LIMITATION, useIsFileSizeLessThanLimitation, useIsFileTypeImage } from "@/hooks/useValidation";
 import theme from "@/assets/styles/theme";
-import { useUploadUserProfileImage } from "@/api/user";
+import { useDeleteUserProfileImage, useUploadUserProfileImage } from "@/api/user";
 import { useDefaultSnackbar } from "@/hooks/useWarningSnackbar";
 
 function UserImageChangeWrapper({ mode, profileUrl }: { mode: string, profileUrl?: string }) {
@@ -50,9 +50,10 @@ function UserImageChangeWrapper({ mode, profileUrl }: { mode: string, profileUrl
     }
 
     const { uploadUserProfileImageMutate } = useUploadUserProfileImage();
-
+    const { deleteUserProfileImageMutate } = useDeleteUserProfileImage();
     const handleRemoveImage = () => {
-        setImage('');
+        deleteUserProfileImageMutate();
+        // setImage('');
     }
 
     const handleUploadUserProfileImage = (file: File | null) => {

--- a/src/components/molcules/UserPage/UserNicknameChangeWrapper.tsx
+++ b/src/components/molcules/UserPage/UserNicknameChangeWrapper.tsx
@@ -1,0 +1,9 @@
+function UserNicknameChangeWrapper() {
+    return (
+        <div>
+
+        </div>
+    );
+}
+
+export default UserNicknameChangeWrapper;

--- a/src/components/molcules/UserPage/UserNicknameChangeWrapper.tsx
+++ b/src/components/molcules/UserPage/UserNicknameChangeWrapper.tsx
@@ -1,7 +1,8 @@
 import { useEditUserNickname } from "@/api/user";
 import theme from "@/assets/styles/theme";
+import { MAX_USER_NICKNAME_LENGTH, useIsBlank, useIsLessThanLengthLimitation } from "@/hooks/useValidation";
 import { useIsUserPageViewMode } from "@/pages/UserPage";
-import { Box, Typography, OutlinedInput, Button } from "@mui/material";
+import { Box, Typography, OutlinedInput, Button, FormHelperText } from "@mui/material";
 import { useState } from "react";
 
 interface UserNicknameChangeWrapperProps {
@@ -16,11 +17,33 @@ function UserNicknameChangeWrapper({ mode, nickname, changeModeIntoView }: UserN
         setNicknameInput(event.target.value);
     }
 
-    const { editUserNicknameMutate } = useEditUserNickname();
+    const { mutate, error } = useEditUserNickname();
+    const isNicknameExist = (error: any) => error.message === 'BR003';
     const handleEditUserNickname = () => {
-        changeModeIntoView();
-        editUserNicknameMutate(nicknameInput);
+        mutate(nicknameInput);
+        if (isNicknameExist(error)) {
+            return;
+        }
+        changeModeIntoView()
     }
+
+    const validateUserNickname = () => {
+        if (useIsBlank(nicknameInput)) {
+            return '닉네임을 입력해주세요.';
+        }
+
+        if (!useIsLessThanLengthLimitation(nicknameInput, MAX_USER_NICKNAME_LENGTH)) {
+            return '닉네임은 10글자 이하로 입력해주세요.';
+        }
+
+        if (!isNicknameInputChanged()) {
+            return '닉네임이 변경되지 않았습니다.';
+        }
+
+        return;
+    }
+
+    const isNicknameInputChanged = () => nicknameInput !== nickname;
 
     if (useIsUserPageViewMode(mode)) {
         return;
@@ -35,42 +58,53 @@ function UserNicknameChangeWrapper({ mode, nickname, changeModeIntoView }: UserN
                 width: '100%',
             }}
         >
-            <Box
-                sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '13px',
-                    mt: '100px',
-                    width: '100%',
-                    justifyContent: 'center',
-                }}
-            >
-                <Typography
+            <Box>
+                <Box
                     sx={{
-                        fontWeight: '600',
-                        fontSize: '16px',
-                        lineHeight: '150%',
-                        color: theme.color.Gray_090,
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '13px',
+                        mt: '100px',
+                        width: '100%',
+                        justifyContent: 'center',
                     }}
                 >
-                    닉네임:
-                </Typography>
-                <OutlinedInput
-                    value={nicknameInput}
+                    <Typography
+                        sx={{
+                            fontWeight: '600',
+                            fontSize: '16px',
+                            lineHeight: '150%',
+                            color: theme.color.Gray_090,
+                        }}
+                    >
+                        닉네임:
+                    </Typography>
+                    <OutlinedInput
+                        value={nicknameInput}
+                        sx={{
+                            maxWidth: {
+                                xs: '215px',
+                                sm: '260px',
+                            },
+                            'input': {
+                                p: '8px 0 8px 12px',
+                                backgroundColor: '#FFF',
+                                borderRadius: '8px',
+                                border: `1px solid ${theme.color.Gray_040}`
+                            }
+                        }}
+                        onChange={handleNicknameInputChange}
+                    />
+                </Box>
+                <FormHelperText
                     sx={{
-                        maxWidth: {
-                            xs: '215px',
-                            sm: '260px',
-                        },
-                        'input': {
-                            p: '8px 0 8px 12px',
-                            backgroundColor: '#FFF',
-                            borderRadius: '8px',
-                            border: `1px solid ${theme.color.Gray_040}`
-                        }
+                        width: '100%',
+                        display: 'flex',
+                        justifyContent: 'flex-end',
                     }}
-                    onChange={handleNicknameInputChange}
-                />
+                >
+                    {validateUserNickname()}
+                </FormHelperText>
             </Box>
             <Button
                 variant='contained'
@@ -79,6 +113,7 @@ function UserNicknameChangeWrapper({ mode, nickname, changeModeIntoView }: UserN
                     width: '180px',
                 }}
                 onClick={handleEditUserNickname}
+                disabled={!!validateUserNickname()}
             >
                 프로필 변경하기
             </Button>

--- a/src/components/molcules/UserPage/UserNicknameChangeWrapper.tsx
+++ b/src/components/molcules/UserPage/UserNicknameChangeWrapper.tsx
@@ -1,8 +1,72 @@
-function UserNicknameChangeWrapper() {
-    return (
-        <div>
+import theme from "@/assets/styles/theme";
+import { useIsUserPageViewMode } from "@/pages/UserPage";
+import { Box, Typography, OutlinedInput, Button } from "@mui/material";
 
-        </div>
+interface UserNicknameChangeWrapperProps {
+    mode: string;
+    nickname: string;
+    changeModeIntoView: () => void;
+}
+
+function UserNicknameChangeWrapper({ mode, nickname, changeModeIntoView }: UserNicknameChangeWrapperProps) {
+    if (useIsUserPageViewMode(mode)) {
+        return null;
+    }
+    return (
+        <Box
+            sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                width: '100%',
+            }}
+        >
+            <Box
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '13px',
+                    mt: '100px',
+                    width: '100%',
+                    justifyContent: 'center',
+                }}
+            >
+                <Typography
+                    sx={{
+                        fontWeight: '600',
+                        fontSize: '16px',
+                        lineHeight: '150%',
+                        color: theme.color.Gray_090,
+                    }}
+                >
+                    닉네임:
+                </Typography>
+                <OutlinedInput
+                    value={nickname}
+                    sx={{
+                        maxWidth: {
+                            xs: '215px',
+                            sm: '260px',
+                        },
+                        'input': {
+                            p: '8px 0 8px 12px',
+                            backgroundColor: '#FFF',
+                            borderRadius: '8px',
+                            border: `1px solid ${theme.color.Gray_040}`
+                        }
+                    }} />
+            </Box>
+            <Button
+                variant='contained'
+                sx={{
+                    m: '60px 0 32px 0',
+                    width: '180px',
+                }}
+                onClick={changeModeIntoView}
+            >
+                프로필 변경하기
+            </Button>
+        </Box>
     );
 }
 

--- a/src/components/molcules/UserPage/UserNicknameChangeWrapper.tsx
+++ b/src/components/molcules/UserPage/UserNicknameChangeWrapper.tsx
@@ -1,9 +1,11 @@
+import { Box, Typography, OutlinedInput, Button, FormHelperText } from "@mui/material";
+import { useState } from "react";
+
 import { useEditUserNickname } from "@/api/user";
 import theme from "@/assets/styles/theme";
 import { MAX_USER_NICKNAME_LENGTH, useIsBlank, useIsLessThanLengthLimitation } from "@/hooks/useValidation";
+
 import { useIsUserPageViewMode } from "@/pages/UserPage";
-import { Box, Typography, OutlinedInput, Button, FormHelperText } from "@mui/material";
-import { useState } from "react";
 
 interface UserNicknameChangeWrapperProps {
     mode: string;

--- a/src/components/molcules/UserPage/UserNicknameChangeWrapper.tsx
+++ b/src/components/molcules/UserPage/UserNicknameChangeWrapper.tsx
@@ -37,7 +37,7 @@ function UserNicknameChangeWrapper({ mode, nickname, changeModeIntoView }: UserN
         }
 
         if (!isNicknameInputChanged()) {
-            return '닉네임이 변경되지 않았습니다.';
+            return ' ';
         }
 
         return;

--- a/src/components/molcules/UserPage/UserNicknameChangeWrapper.tsx
+++ b/src/components/molcules/UserPage/UserNicknameChangeWrapper.tsx
@@ -1,6 +1,8 @@
+import { useEditUserNickname } from "@/api/user";
 import theme from "@/assets/styles/theme";
 import { useIsUserPageViewMode } from "@/pages/UserPage";
 import { Box, Typography, OutlinedInput, Button } from "@mui/material";
+import { useState } from "react";
 
 interface UserNicknameChangeWrapperProps {
     mode: string;
@@ -9,9 +11,21 @@ interface UserNicknameChangeWrapperProps {
 }
 
 function UserNicknameChangeWrapper({ mode, nickname, changeModeIntoView }: UserNicknameChangeWrapperProps) {
-    if (useIsUserPageViewMode(mode)) {
-        return null;
+    const [nicknameInput, setNicknameInput] = useState(nickname);
+    const handleNicknameInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setNicknameInput(event.target.value);
     }
+
+    const { editUserNicknameMutate } = useEditUserNickname();
+    const handleEditUserNickname = () => {
+        changeModeIntoView();
+        editUserNicknameMutate(nicknameInput);
+    }
+
+    if (useIsUserPageViewMode(mode)) {
+        return;
+    }
+
     return (
         <Box
             sx={{
@@ -42,7 +56,7 @@ function UserNicknameChangeWrapper({ mode, nickname, changeModeIntoView }: UserN
                     닉네임:
                 </Typography>
                 <OutlinedInput
-                    value={nickname}
+                    value={nicknameInput}
                     sx={{
                         maxWidth: {
                             xs: '215px',
@@ -54,7 +68,9 @@ function UserNicknameChangeWrapper({ mode, nickname, changeModeIntoView }: UserN
                             borderRadius: '8px',
                             border: `1px solid ${theme.color.Gray_040}`
                         }
-                    }} />
+                    }}
+                    onChange={handleNicknameInputChange}
+                />
             </Box>
             <Button
                 variant='contained'
@@ -62,7 +78,7 @@ function UserNicknameChangeWrapper({ mode, nickname, changeModeIntoView }: UserN
                     m: '60px 0 32px 0',
                     width: '180px',
                 }}
-                onClick={changeModeIntoView}
+                onClick={handleEditUserNickname}
             >
                 프로필 변경하기
             </Button>

--- a/src/hooks/useValidation.ts
+++ b/src/hooks/useValidation.ts
@@ -9,6 +9,8 @@ export const MAX_SCRAP_PRICE_LENGTH = 100;
 export const MAX_SCRAP_CHANNELNAME_LENGTH = 100;
 export const MAX_BOARD_DESCRIPTION_LENGTH = 1000;
 export const MAX_BOARD_TITLE_LENGTH = 50;
+export const MAX_USER_NICKNAME_LENGTH = 10;
+
 export const IMAGE_FILE_SIZE_LIMITATION = 1024 * 1024 * 10;
 
 export function useIsValidURL(url: string) {

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -3,12 +3,12 @@ import { Box, Button, OutlinedInput, Typography } from '@mui/material';
 import { useState } from 'react';
 
 import theme from '@/assets/styles/theme';
-import defaultUserImage from '@/assets/images/Avatar.png';
 import { useGetUserInformation } from '@/api/user';
 
 import { DarkWaveVector, EditPencilSquareIcon, LightWaveVector } from '@/components/atoms/Icon';
 import UserInfoTable from '@/components/molcules/UserPage/UserInfoTable';
 import UserActionButtonGroup from '@/components/molcules/UserPage/UserActionButtonGroup';
+import UserImageChangeWrapper from '@/components/molcules/UserPage/UserImageChangeWrapper';
 
 export const useIsUserPageEditMode = (mode: string) => {
     return mode === 'edit';
@@ -51,38 +51,6 @@ function UserPage() {
         setMode('view');
     }
 
-    function UserImage({ mode }: { mode: string }) {
-        return (
-            <Box
-                sx={{
-                    position: 'absolute',
-                    top: '-25%',
-                }}
-            >
-                <Box>
-                    {profileUrl
-                        ? <ProfileImage src={profileUrl} />
-                        : <ProfileImage src={defaultUserImage} />
-                    }
-                    {mode === 'edit' &&
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                width: '100%',
-                                justifyContent: 'center',
-                                gap: '8px',
-                                mt: '24px',
-                            }}
-                        >
-                            <Button sx={grayOutlinedButtonStyle}>이미지 변경</Button>
-                            <Button sx={grayFullfilledButtonStyle}>이미지 삭제</Button>
-                        </Box>
-                    }
-                </Box>
-            </Box>
-        )
-    }
-
     return (
         <Wrapper>
             <Box
@@ -110,7 +78,7 @@ function UserPage() {
                 }}
             >
                 <UserInfoWrapper>
-                    <UserImage mode={mode} />
+                    <UserImageChangeWrapper mode={mode} profileUrl={profileUrl} />
                     <Box
                         sx={{
                             display: 'flex',
@@ -202,12 +170,6 @@ const Wrapper = styled.div`
     align-items: center;
     padding: 24px;
     box-sizing: border-box;
-`
-
-const ProfileImage = styled.img`
-    width: 200px;
-    height: 200px;
-    border-radius: 100%;
 `
 
 const UserInfoWrapper = styled.div`

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { Box, Button, OutlinedInput, Typography } from '@mui/material';
+import { Box, Button } from '@mui/material';
 import { useState } from 'react';
 
 import theme from '@/assets/styles/theme';
@@ -52,8 +52,8 @@ function UserPage() {
         setMode('view');
     }
 
-    return (
-        <Wrapper>
+    function WaveVector({ vector }: { vector: JSX.Element }) {
+        return (
             <Box
                 sx={{
                     position: 'fixed',
@@ -61,8 +61,15 @@ function UserPage() {
                     overflow: 'hidden',
                 }}
             >
-                <LightWaveVector />
+                {vector}
             </Box>
+        )
+    }
+
+    return (
+        <Wrapper>
+            <WaveVector vector={<LightWaveVector />} />
+            <WaveVector vector={<DarkWaveVector />} />
             <Box
                 sx={{
                     position: 'fixed',

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -9,6 +9,7 @@ import { DarkWaveVector, EditPencilSquareIcon, LightWaveVector } from '@/compone
 import UserInfoTable from '@/components/molcules/UserPage/UserInfoTable';
 import UserActionButtonGroup from '@/components/molcules/UserPage/UserActionButtonGroup';
 import UserImageChangeWrapper from '@/components/molcules/UserPage/UserImageChangeWrapper';
+import UserNicknameChangeWrapper from '@/components/molcules/UserPage/UserNicknameChangeWrapper';
 
 export const useIsUserPageEditMode = (mode: string) => {
     return mode === 'edit';
@@ -93,55 +94,8 @@ function UserPage() {
                         }}
                     >
                         <UserInfoTable userInformation={userInformation} mode={mode} />
-                        {useIsUserPageEditMode(mode) &&
-                            <Box
-                                sx={{
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    gap: '13px',
-                                    mt: '100px',
-                                    width: '100%',
-                                    justifyContent: 'center',
-                                }}
-                            >
-                                <Typography
-                                    sx={{
-                                        fontWeight: '600',
-                                        fontSize: '16px',
-                                        lineHeight: '150%',
-                                        color: theme.color.Gray_090,
-                                    }}
-                                >닉네임: </Typography>
-                                <OutlinedInput
-                                    value={nickname}
-                                    sx={{
-                                        width: {
-                                            xs: '217px',
-                                            sm: '260px',
-                                        },
-                                        'input': {
-                                            p: '8px 0 8px 12px',
-                                            backgroundColor: '#FFF',
-                                            borderRadius: '8px',
-                                            border: `1px solid ${theme.color.Gray_040}`
-                                        }
-                                    }} />
-                            </Box>
-                        }
+                        <UserNicknameChangeWrapper mode={mode} nickname={nickname} changeModeIntoView={changeModeIntoView} />
                     </Box>
-                    {
-                        useIsUserPageEditMode(mode)
-                        && <Button
-                            variant='contained'
-                            sx={{
-                                m: '60px 0 32px 0',
-                                width: '180px',
-                            }}
-                            onClick={changeModeIntoView}
-                        >
-                            프로필 변경하기
-                        </Button>
-                    }
                     {
                         useIsUserPageViewMode(mode)
                         && <Button


### PR DESCRIPTION
## 개요
- DAD-1138

## 작업사항
- 유저 이미지 변경, 삭제
- 유저 닉네임 변경 구현
- 유저 닉네임 validation은 notblank, 10자 제한, 변경되지 않은 닉네임으로 구별
- 이미지 변경 및 삭제 후 헤더 이미지도 변경되도록 설정 -> 처음 헤더 이미지 바뀔 때처럼 클릭해야 바뀜

## 변경로직(Optional)
- 유저 페이지 컴포넌트 분리 약간 추가됨