### PR TITLE
[DAD-1156] 오류 해결

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -188,7 +188,11 @@ const editUserNickname = async (nickname: string) => {
 	return response;
 };
 
-export const useEditUserNickname = () => {
+export const useEditUserNickname = ({
+	changeModeIntoView,
+}: {
+	changeModeIntoView: () => void;
+}) => {
 	const queryClient = useQueryClient();
 	const isExistName = (error: any) => error.message === "BR003";
 
@@ -199,6 +203,7 @@ export const useEditUserNickname = () => {
 				"닉네임이 변경되었습니다.",
 				"success"
 			);
+			changeModeIntoView();
 		},
 		onError: (error: any) => {
 			isExistName(error)

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -234,9 +234,13 @@ const deleteUserProfileImage = async () => {
 	});
 };
 
-export const useDeleteUserProfileImage = () => {
+export const useDeleteUserProfileImage = ({
+	changeModeIntoView,
+}: {
+	changeModeIntoView: () => void;
+}) => {
 	const queryClient = useQueryClient();
-	const { mutate, isSuccess } = useMutation(deleteUserProfileImage, {
+	const { mutate } = useMutation(deleteUserProfileImage, {
 		onSuccess: () => {
 			queryClient.invalidateQueries(["userInformation"]);
 			useDefaultSnackbar(
@@ -244,6 +248,7 @@ export const useDeleteUserProfileImage = () => {
 				"success"
 			);
 			localStorage.setItem("profileImageURL", "");
+			changeModeIntoView();
 		},
 		onError: (error) => {
 			Sentry.captureException(error);
@@ -256,12 +261,8 @@ export const useDeleteUserProfileImage = () => {
 		retry: false,
 	});
 
-	const [
-		deleteUserProfileImageMutate,
-		isDeleteUserProfileImageMutateSuccess,
-	] = [mutate, isSuccess];
+	const [deleteUserProfileImageMutate] = [mutate];
 	return {
 		deleteUserProfileImageMutate,
-		isDeleteUserProfileImageMutateSuccess,
 	};
 };

--- a/src/components/molcules/UserPage/UserImage.tsx
+++ b/src/components/molcules/UserPage/UserImage.tsx
@@ -1,0 +1,34 @@
+import { ProfileIcon } from "@/components/atoms/Icon";
+import { Box } from "@mui/material";
+
+function UserImage({ profileUrl }: { profileUrl?: string }) {
+    return (
+        <Box
+            sx={{
+                position: 'absolute',
+                top: '-25%',
+            }}
+        >
+            {
+                profileUrl
+                    ? <img
+                        src={profileUrl}
+                        alt="프로필 이미지"
+                        style={{
+                            width: '200px',
+                            height: '200px',
+                            borderRadius: '100%',
+                        }}
+                        className="profile-image"
+                    />
+                    : <Box
+                        className="profile-image"
+                    >
+                        <ProfileIcon size="200" />
+                    </Box>
+            }
+        </Box>
+    );
+}
+
+export default UserImage;

--- a/src/components/molcules/UserPage/UserImageByModeWrapper.tsx
+++ b/src/components/molcules/UserPage/UserImageByModeWrapper.tsx
@@ -2,13 +2,13 @@ import UserImage from "@/components/molcules/UserPage/UserImage";
 import UserImageChangeWrapper from "@/components/molcules/UserPage/UserImageChangeWrapper";
 import { useIsUserPageViewMode } from "@/pages/UserPage";
 
-function UserImageByModeWrapper({ profileUrl, mode }: { profileUrl?: string, mode: string }) {
+function UserImageByModeWrapper({ profileUrl, mode, changeModeIntoView }: { profileUrl?: string, mode: string, changeModeIntoView: () => void }) {
     if (useIsUserPageViewMode(mode)) {
         return <UserImage profileUrl={profileUrl} />
     }
 
     return (
-        <UserImageChangeWrapper profileUrl={profileUrl} />
+        <UserImageChangeWrapper profileUrl={profileUrl} changeModeIntoView={changeModeIntoView} />
     );
 }
 

--- a/src/components/molcules/UserPage/UserImageByModeWrapper.tsx
+++ b/src/components/molcules/UserPage/UserImageByModeWrapper.tsx
@@ -1,0 +1,15 @@
+import UserImage from "@/components/molcules/UserPage/UserImage";
+import UserImageChangeWrapper from "@/components/molcules/UserPage/UserImageChangeWrapper";
+import { useIsUserPageViewMode } from "@/pages/UserPage";
+
+function UserImageByModeWrapper({ profileUrl, mode }: { profileUrl?: string, mode: string }) {
+    if (useIsUserPageViewMode(mode)) {
+        return <UserImage profileUrl={profileUrl} />
+    }
+
+    return (
+        <UserImageChangeWrapper profileUrl={profileUrl} />
+    );
+}
+
+export default UserImageByModeWrapper;

--- a/src/components/molcules/UserPage/UserImageChangeWrapper.tsx
+++ b/src/components/molcules/UserPage/UserImageChangeWrapper.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Typography } from "@mui/material";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import useGetPreviewFile from "@/hooks/useGetPrevieFile";
 import { IMAGE_FILE_SIZE_LIMITATION, useIsFileSizeLessThanLimitation, useIsFileTypeImage } from "@/hooks/useValidation";
@@ -10,7 +10,7 @@ import { useDefaultSnackbar } from "@/hooks/useWarningSnackbar";
 import { ProfileIcon } from "@/components/atoms/Icon";
 import { grayOutlinedButtonStyle, grayFullfilledButtonStyle } from "@/pages/UserPage";
 
-function UserImageChangeWrapper({ profileUrl }: { profileUrl?: string }) {
+function UserImageChangeWrapper({ profileUrl, changeModeIntoView }: { profileUrl?: string, changeModeIntoView: () => void }) {
     const [requestPrevieFile, file] = useGetPreviewFile();
     const [image, setImage] = useState(profileUrl);
 
@@ -50,13 +50,10 @@ function UserImageChangeWrapper({ profileUrl }: { profileUrl?: string }) {
     }
 
     const { uploadUserProfileImageMutate } = useUploadUserProfileImage();
-    const { deleteUserProfileImageMutate, isDeleteUserProfileImageMutateSuccess } = useDeleteUserProfileImage();
+    const { deleteUserProfileImageMutate } = useDeleteUserProfileImage({ changeModeIntoView });
     const handleRemoveImage = () => {
         deleteUserProfileImageMutate();
-        if (isDeleteUserProfileImageMutateSuccess) {
-            setImage(undefined);
-        }
-    }
+    };
 
     const handleUploadUserProfileImage = (file: File | null) => {
         if (!file) {
@@ -65,6 +62,7 @@ function UserImageChangeWrapper({ profileUrl }: { profileUrl?: string }) {
         }
 
         uploadUserProfileImageMutate(file);
+        changeModeIntoView();
     }
 
     function ProfileImage({ src }: { src?: string }) {
@@ -114,6 +112,7 @@ function UserImageChangeWrapper({ profileUrl }: { profileUrl?: string }) {
             </Typography>
         </Box>
     }
+
     return (
         <Box
             sx={{

--- a/src/components/molcules/UserPage/UserImageChangeWrapper.tsx
+++ b/src/components/molcules/UserPage/UserImageChangeWrapper.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Typography } from "@mui/material";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import useGetPreviewFile from "@/hooks/useGetPrevieFile";
 import { IMAGE_FILE_SIZE_LIMITATION, useIsFileSizeLessThanLimitation, useIsFileTypeImage } from "@/hooks/useValidation";

--- a/src/components/molcules/UserPage/UserImageChangeWrapper.tsx
+++ b/src/components/molcules/UserPage/UserImageChangeWrapper.tsx
@@ -8,9 +8,9 @@ import { useDeleteUserProfileImage, useUploadUserProfileImage } from "@/api/user
 import { useDefaultSnackbar } from "@/hooks/useWarningSnackbar";
 
 import { ProfileIcon } from "@/components/atoms/Icon";
-import { grayOutlinedButtonStyle, grayFullfilledButtonStyle, useIsUserPageEditMode } from "@/pages/UserPage";
+import { grayOutlinedButtonStyle, grayFullfilledButtonStyle } from "@/pages/UserPage";
 
-function UserImageChangeWrapper({ mode, profileUrl }: { mode: string, profileUrl?: string }) {
+function UserImageChangeWrapper({ profileUrl }: { profileUrl?: string }) {
     const [requestPrevieFile, file] = useGetPreviewFile();
     const [image, setImage] = useState(profileUrl);
 
@@ -123,30 +123,28 @@ function UserImageChangeWrapper({ mode, profileUrl }: { mode: string, profileUrl
         >
             <Box>
                 <ProfileImage src={image} />
-                {useIsUserPageEditMode(mode) &&
-                    <Box
-                        sx={{
-                            display: 'flex',
-                            width: '100%',
-                            justifyContent: 'center',
-                            gap: '8px',
-                            mt: '24px',
-                        }}
+                <Box
+                    sx={{
+                        display: 'flex',
+                        width: '100%',
+                        justifyContent: 'center',
+                        gap: '8px',
+                        mt: '24px',
+                    }}
+                >
+                    <Button
+                        sx={grayOutlinedButtonStyle}
+                        onClick={() => handleUploadUserProfileImage(file)}
                     >
-                        <Button
-                            sx={grayOutlinedButtonStyle}
-                            onClick={() => handleUploadUserProfileImage(file)}
-                        >
-                            이미지 변경
-                        </Button>
-                        <Button
-                            sx={grayFullfilledButtonStyle}
-                            onClick={handleRemoveImage}
-                        >
-                            이미지 삭제
-                        </Button>
-                    </Box>
-                }
+                        이미지 변경
+                    </Button>
+                    <Button
+                        sx={grayFullfilledButtonStyle}
+                        onClick={handleRemoveImage}
+                    >
+                        이미지 삭제
+                    </Button>
+                </Box>
             </Box>
         </Box>
     );

--- a/src/components/molcules/UserPage/UserNicknameChangeWrapper.tsx
+++ b/src/components/molcules/UserPage/UserNicknameChangeWrapper.tsx
@@ -19,14 +19,10 @@ function UserNicknameChangeWrapper({ mode, nickname, changeModeIntoView }: UserN
         setNicknameInput(event.target.value);
     }
 
-    const { mutate, error } = useEditUserNickname();
+    const { mutate } = useEditUserNickname({ changeModeIntoView });
     const isNicknameExist = (error: any) => error.message === 'BR003';
     const handleEditUserNickname = () => {
         mutate(nicknameInput);
-        if (isNicknameExist(error)) {
-            return;
-        }
-        changeModeIntoView()
     }
 
     const validateUserNickname = () => {

--- a/src/components/organisms/ExistCategoryScrapContainer/CategoryInfo.tsx
+++ b/src/components/organisms/ExistCategoryScrapContainer/CategoryInfo.tsx
@@ -5,7 +5,8 @@ import MemoList from '@/components/molcules/CategoryItem/Memo/MemoList';
 import { MoveToPageIcon } from '@/components/atoms/Icon';
 
 function CategoryInfo({ data, scrapId }: { data: any, scrapId: number }) {
-    const selectedScrap = data?.pages[0].data.content.find((scrap: any) => scrap.scrapId === scrapId);
+    let selectedScrap = data?.pages[0].data.content.find((scrap: any) => scrap.scrapId === scrapId);
+    selectedScrap = typeof selectedScrap === 'undefined' ? data?.pages[0].data.content[0] : selectedScrap;
 
     return (
         <>

--- a/src/components/organisms/ExistCategoryScrapContainer/CategoryInfo.tsx
+++ b/src/components/organisms/ExistCategoryScrapContainer/CategoryInfo.tsx
@@ -3,9 +3,14 @@ import { Box } from '@mui/material';
 
 import MemoList from '@/components/molcules/CategoryItem/Memo/MemoList';
 import { MoveToPageIcon } from '@/components/atoms/Icon';
+import { contentProps } from '@/types/ContentType';
 
 function CategoryInfo({ data, scrapId }: { data: any, scrapId: number }) {
-    let selectedScrap = data?.pages[0].data.content.find((scrap: any) => scrap.scrapId === scrapId);
+    function findScrapById(scrapId: number) {
+        return data?.pages.flatMap((page: any) => page.data.content.filter((scrap: contentProps['content']) => scrap.scrapId === scrapId));
+    }
+
+    let selectedScrap = findScrapById(scrapId)[0];
     selectedScrap = typeof selectedScrap === 'undefined' ? data?.pages[0].data.content[0] : selectedScrap;
 
     return (

--- a/src/components/templates/ColumnListTemplate.tsx
+++ b/src/components/templates/ColumnListTemplate.tsx
@@ -83,7 +83,7 @@ function ColumnListTemplate({ type }: { type: string }) {
                 >
                     <CategoryList data={data} fetchNextPage={fetchNextPage} hasNextPage={hasNextPage} />
                 </Box>
-                <CategoryInfo data={data} scrapId={scrapId ? +scrapId : data?.pages[0].data.content[0].scrapId} />
+                <CategoryInfo data={data} scrapId={typeof scrapId === 'string' ? +scrapId : data?.pages[0].data.content[0].scrapId} />
             </Desktop >
         </Box>
     )

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -8,7 +8,6 @@ import { useGetUserInformation } from '@/api/user';
 import { DarkWaveVector, EditPencilSquareIcon, LightWaveVector } from '@/components/atoms/Icon';
 import UserInfoTable from '@/components/molcules/UserPage/UserInfoTable';
 import UserActionButtonGroup from '@/components/molcules/UserPage/UserActionButtonGroup';
-import UserImageChangeWrapper from '@/components/molcules/UserPage/UserImageChangeWrapper';
 import UserNicknameChangeWrapper from '@/components/molcules/UserPage/UserNicknameChangeWrapper';
 import UserImageByModeWrapper from '@/components/molcules/UserPage/UserImageByModeWrapper';
 
@@ -87,7 +86,7 @@ function UserPage() {
                 }}
             >
                 <UserInfoWrapper>
-                    <UserImageByModeWrapper profileUrl={profileUrl} mode={mode} />
+                    <UserImageByModeWrapper profileUrl={profileUrl} mode={mode} changeModeIntoView={changeModeIntoView} />
                     <Box
                         sx={{
                             display: 'flex',

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -10,6 +10,7 @@ import UserInfoTable from '@/components/molcules/UserPage/UserInfoTable';
 import UserActionButtonGroup from '@/components/molcules/UserPage/UserActionButtonGroup';
 import UserImageChangeWrapper from '@/components/molcules/UserPage/UserImageChangeWrapper';
 import UserNicknameChangeWrapper from '@/components/molcules/UserPage/UserNicknameChangeWrapper';
+import UserImageByModeWrapper from '@/components/molcules/UserPage/UserImageByModeWrapper';
 
 export const useIsUserPageEditMode = (mode: string) => {
     return mode === 'edit';
@@ -86,7 +87,7 @@ function UserPage() {
                 }}
             >
                 <UserInfoWrapper>
-                    <UserImageChangeWrapper mode={mode} profileUrl={profileUrl} />
+                    <UserImageByModeWrapper profileUrl={profileUrl} mode={mode} />
                     <Box
                         sx={{
                             display: 'flex',


### PR DESCRIPTION
## 개요
- DAD-1156

## 작업사항
- 스크랩 페이지 이동 반복 및 스크랩 선택 반복 시 오류 해결
- 스크랩 페이지 30번째 이상의 스크랩 클릭 불가 오류 해결
- 유저 페이지 이미지 보기 모드일 때 선택 불가 추가
- 유저 페이지 이미지 변경 및 삭제 후 바로 렌더링 안 되는 오류 해결

## 변경로직(Optional)
- 이미지 변경 및 삭제를 클릭하면 유저 페이지의 보기 모드로 보내도록 수정하였습니다.