### PR TITLE
[DAD-1162] fix: 아이콘 영역과 스크롤 영역 맞추기

### DIFF
--- a/src/pages/BoardInfoPage.tsx
+++ b/src/pages/BoardInfoPage.tsx
@@ -94,7 +94,7 @@ function BoardInfoPage() {
                     left: '0',
                     width: {
                         xs: '100%',
-                        sm: 'calc(100% - 100px)',
+                        sm: 'calc(100% - 86px)',
                     },
                     height: '100%',
                     overflow: 'auto',


### PR DESCRIPTION
## 개요
- DAD-1162

## 작업사항
- 아이콘 영역과 스크롤 영역 맞추기

## 수정된 UI
<img width="1329" alt="image" src="https://github.com/SWM-team-forever/dadamda-frontend/assets/75533232/d870d52e-d26a-4064-8d2f-b91f7c720487">

## 수정전 UI
<img width="1332" alt="image" src="https://github.com/SWM-team-forever/dadamda-frontend/assets/75533232/e36b9f97-cfc3-4707-b85f-12c2f654cfeb">
